### PR TITLE
Add support for dependencies and primitive shapes that require them

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenPlugin.java
@@ -37,9 +37,10 @@ public final class GoCodegenPlugin implements SmithyBuildPlugin {
     /**
      * Creates a Go symbol provider.
      * @param model The model to generate symbols for.
+     * @param rootModuleName The name of the package root.
      * @return Returns the created provider.
      */
-    public static SymbolProvider createSymbolProvider(Model model) {
-        return new SymbolVisitor(model);
+    public static SymbolProvider createSymbolProvider(Model model, String rootModuleName) {
+        return new SymbolVisitor(model, rootModuleName);
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.smithy.codegen.core.SymbolDependency;
+import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+
+/**
+ * An enum of all the built-in dependencies used by this package.
+ */
+public enum GoDependency implements SymbolDependencyContainer {
+
+    // The version in the stdlib dependencies should reflect the minimum Go version.
+    // The values aren't currently used, but they could potentially used to dynamically
+    // set the minimum go version.
+    BIG("stdlib", "math/big", "1.14"),
+    TIME("stdlib", "time", "1.14");
+
+    public final String packageName;
+    public final String version;
+    public final SymbolDependency dependency;
+
+    GoDependency(String type, String name, String version) {
+        this.dependency = SymbolDependency.builder()
+                .dependencyType(type)
+                .packageName(name)
+                .version(version)
+                .build();
+        this.packageName = name;
+        this.version = version;
+    }
+
+    @Override
+    public List<SymbolDependency> getDependencies() {
+        return Collections.singletonList(dependency);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -15,10 +15,21 @@
 
 package software.amazon.smithy.go.codegen;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringJoiner;
 import java.util.function.BiFunction;
+import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolContainer;
+import software.amazon.smithy.codegen.core.SymbolDependency;
+import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Specialized code writer for managing Go dependencies.
@@ -27,7 +38,11 @@ import software.amazon.smithy.utils.CodeWriter;
  */
 public final class GoWriter extends CodeWriter {
 
+    private static final Logger LOGGER = Logger.getLogger(GoWriter.class.getName());
+
     private final String fullPackageName;
+    private final ImportDeclarations imports = new ImportDeclarations();
+    private final List<SymbolDependency> dependencies = new ArrayList<>();
 
     public GoWriter(String fullPackageName) {
         this.fullPackageName = fullPackageName;
@@ -37,6 +52,107 @@ public final class GoWriter extends CodeWriter {
         putFormatter('T', new GoSymbolFormatter());
     }
 
+    /**
+     * Imports one or more symbols if necessary, using the name of the
+     * symbol and only "USE" references.
+     *
+     * @param container Container of symbols to add.
+     * @return Returns the writer.
+     */
+    public GoWriter addUseImports(SymbolContainer container) {
+        for (Symbol symbol : container.getSymbols()) {
+            addImport(symbol,
+                    CodegenUtils.getDefaultPackageImportName(symbol.getNamespace()),
+                    SymbolReference.ContextOption.USE);
+        }
+        return this;
+    }
+
+    /**
+     * Imports a symbol reference if necessary, using the alias of the
+     * reference and only associated "USE" references.
+     *
+     * @param symbolReference Symbol reference to import.
+     * @return Returns the writer.
+     */
+    public GoWriter addUseImports(SymbolReference symbolReference) {
+        return addImport(symbolReference.getSymbol(), symbolReference.getAlias(), SymbolReference.ContextOption.USE);
+    }
+
+    /**
+     * Imports a symbol if necessary using a package alias and list of context options.
+     *
+     * @param symbol Symbol to optionally import.
+     * @param packageAlias The alias to refer to the symbol's package by.
+     * @param options The list of context options (e.g., is it a USE or DECLARE symbol).
+     * @return Returns the writer.
+     */
+    public GoWriter addImport(Symbol symbol, String packageAlias, SymbolReference.ContextOption... options) {
+        LOGGER.finest(() -> {
+            StringJoiner stackTrace = new StringJoiner("\n");
+            for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+                stackTrace.add(element.toString());
+            }
+            return String.format(
+                    "Adding Go import %s as `%s` (%s); Stack trace: %s",
+                    symbol.getNamespace(), packageAlias, Arrays.toString(options), stackTrace);
+        });
+
+        // Always add dependencies.
+        dependencies.addAll(symbol.getDependencies());
+
+        if (!symbol.getNamespace().isEmpty() && !symbol.getNamespace().equals(fullPackageName)) {
+            addImport(symbol.getNamespace(), packageAlias);
+        }
+
+        // Just because the direct symbol wasn't imported doesn't mean that the
+        // symbols it needs to be declared don't need to be imported.
+        addImportReferences(symbol, options);
+
+        return this;
+    }
+
+    void addImportReferences(Symbol symbol, SymbolReference.ContextOption... options) {
+        for (SymbolReference reference : symbol.getReferences()) {
+            for (SymbolReference.ContextOption option : options) {
+                if (reference.hasOption(option)) {
+                    addImport(reference.getSymbol(), reference.getAlias(), options);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Imports a package using an alias if necessary.
+     *
+     * @param packageName Package to import.
+     * @param as Alias to refer to the package as.
+     * @return Returns the writer.
+     */
+    public GoWriter addImport(String packageName, String as) {
+        imports.addImport(packageName, as);
+        return this;
+    }
+
+    /**
+     * Adds one or more dependencies to the generated code.
+     *
+     * <p>The dependencies of all writers created by the {@link GoDelegator}
+     * are merged together to eventually generate a go.mod file.
+     *
+     * @param dependencies Go dependency to add.
+     * @return Returns the writer.
+     */
+    public GoWriter addDependency(SymbolDependencyContainer dependencies) {
+        this.dependencies.addAll(dependencies.getDependencies());
+        return this;
+    }
+
+    Collection<SymbolDependency> getDependencies() {
+        return dependencies;
+    }
+
     @Override
     public String toString() {
         String contents = super.toString();
@@ -44,20 +160,33 @@ public final class GoWriter extends CodeWriter {
         String header = String.format(
                 "// Code generated by smithy-go-codegen DO NOT EDIT.%npackage %s%n%n",
                 packageParts[packageParts.length - 1]);
-        // TODO: add imports
-        return header + contents;
+
+        String importString = imports.toString();
+        String strippedContents = StringUtils.stripStart(contents, null);
+        String strippedImportString = StringUtils.strip(importString, null);
+
+        // Don't add an additional new line between explicit imports and managed imports.
+        if (!strippedImportString.isEmpty() && strippedContents.startsWith("import ")) {
+            return header + strippedImportString + "\n" + strippedContents;
+        }
+
+        return header + importString + contents;
     }
 
     /**
      * Implements Go symbol formatting for the {@code $T} formatter.
      */
-    private static final class GoSymbolFormatter implements BiFunction<Object, String, String> {
+    private final class GoSymbolFormatter implements BiFunction<Object, String, String> {
         @Override
         public String apply(Object type, String indent) {
             if (type instanceof Symbol) {
                 Symbol typeSymbol = (Symbol) type;
-                // TODO: add imports
+                addUseImports(typeSymbol);
                 return typeSymbol.getName();
+            } else if (type instanceof SymbolReference) {
+                SymbolReference typeSymbol = (SymbolReference) type;
+                addImport(typeSymbol.getSymbol(), typeSymbol.getAlias(), SymbolReference.ContextOption.USE);
+                return typeSymbol.getAlias();
             } else {
                 throw new CodegenException(
                         "Invalid type provided to $T. Expected a Symbol, but found `" + type + "`");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ImportDeclarations.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ImportDeclarations.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Map;
+import java.util.TreeMap;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Container and formatter for go imports.
+ */
+final class ImportDeclarations {
+
+    private final Map<String, String> imports = new TreeMap<>();
+
+    ImportDeclarations addImport(String packageName, String alias) {
+        String importedName = CodegenUtils.getDefaultPackageImportName(packageName);
+        if (!StringUtils.isBlank(alias)) {
+            if (alias.equals(".")) {
+                // Global imports are generally a bad practice.
+                throw new CodegenException("Globally importing packages is forbidden: " + packageName);
+            }
+            importedName = alias;
+        }
+        imports.putIfAbsent(importedName, packageName);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        if (imports.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder("import (\n");
+        for (Map.Entry<String, String> entry : imports.entrySet()) {
+            builder.append('\t');
+            builder.append(createImportStatement(entry));
+            builder.append('\n');
+        }
+        builder.append(")\n\n");
+        return builder.toString();
+    }
+
+    private String createImportStatement(Map.Entry<String, String> entry) {
+        String formattedPackageName = "\"" + entry.getValue() + "\"";
+        return CodegenUtils.getDefaultPackageImportName(entry.getValue()).equals(entry.getKey())
+                ? formattedPackageName
+                : entry.getKey() + " " + formattedPackageName;
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -61,7 +61,7 @@ final class StructureGenerator implements Runnable {
     private void writeMembers() {
         for (MemberShape member : shape.getAllMembers().values()) {
             String memberName = symbolProvider.toMemberName(member);
-            writer.write("$L $T", memberName, symbolProvider.toSymbol(member));
+            writer.write("$L $P", memberName, symbolProvider.toSymbol(member));
         }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -100,12 +100,12 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol blobShape(BlobShape shape) {
-        return createSymbolBuilder(shape, "[]byte", false).build();
+        return createSymbolBuilder(shape, "[]byte").build();
     }
 
     @Override
     public Symbol booleanShape(BooleanShape shape) {
-        return createSymbolBuilder(shape, "bool").build();
+        return createPointableSymbolBuilder(shape, "bool").build();
     }
 
     @Override
@@ -123,7 +123,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     private Symbol createCollectionSymbol(CollectionShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return createSymbolBuilder(shape, "[]" + reference.getName(), false)
+        return createSymbolBuilder(shape, "[]" + reference.getName())
                 .addReference(reference)
                 .build();
     }
@@ -131,45 +131,45 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol mapShape(MapShape shape) {
         Symbol reference = toSymbol(shape.getValue());
-        return createSymbolBuilder(shape, "map[string]" + reference.getName(), false)
+        return createSymbolBuilder(shape, "map[string]" + reference.getName())
                 .addReference(reference)
                 .build();
     }
 
     @Override
     public Symbol byteShape(ByteShape shape) {
-        return createSymbolBuilder(shape, "byte").build();
+        return createPointableSymbolBuilder(shape, "byte").build();
     }
 
     @Override
     public Symbol shortShape(ShortShape shape) {
-        return createSymbolBuilder(shape, "int16").build();
+        return createPointableSymbolBuilder(shape, "int16").build();
     }
 
     @Override
     public Symbol integerShape(IntegerShape shape) {
-        return createSymbolBuilder(shape, "int32").build();
+        return createPointableSymbolBuilder(shape, "int32").build();
     }
 
     @Override
     public Symbol longShape(LongShape shape) {
-        return createSymbolBuilder(shape, "int64").build();
+        return createPointableSymbolBuilder(shape, "int64").build();
     }
 
     @Override
     public Symbol floatShape(FloatShape shape) {
-        return createSymbolBuilder(shape, "float32").build();
+        return createPointableSymbolBuilder(shape, "float32").build();
     }
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
         // TODO: implement document shapes
-        return createSymbolBuilder(shape, "nil").build();
+        return createPointableSymbolBuilder(shape, "nil").build();
     }
 
     @Override
     public Symbol doubleShape(DoubleShape shape) {
-        return createSymbolBuilder(shape, "float64").build();
+        return createPointableSymbolBuilder(shape, "float64").build();
     }
 
     @Override
@@ -183,7 +183,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private Symbol createBigSymbol(Shape shape, String symbolName) {
-        return createSymbolBuilder(shape, symbolName)
+        return createPointableSymbolBuilder(shape, symbolName)
                 .addReference(createNamespaceReference(GoDependency.BIG))
                 .build();
     }
@@ -191,31 +191,31 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol operationShape(OperationShape shape) {
         // TODO: implement operations
-        return createSymbolBuilder(shape, "nil").build();
+        return createPointableSymbolBuilder(shape, "nil").build();
     }
 
     @Override
     public Symbol resourceShape(ResourceShape shape) {
         // TODO: implement resources
-        return createSymbolBuilder(shape, "nil").build();
+        return createPointableSymbolBuilder(shape, "nil").build();
     }
 
     @Override
     public Symbol serviceShape(ServiceShape shape) {
         // TODO: implement clients
-        return createSymbolBuilder(shape, "nil").build();
+        return createPointableSymbolBuilder(shape, "nil").build();
     }
 
     @Override
     public Symbol stringShape(StringShape shape) {
         // TODO: support specialized strings
-        return createSymbolBuilder(shape, "string").build();
+        return createPointableSymbolBuilder(shape, "string").build();
     }
 
     @Override
     public Symbol structureShape(StructureShape shape) {
         String name = StringUtils.capitalize(shape.getId().getName());
-        return createSymbolBuilder(shape, name, rootModuleName)
+        return createPointableSymbolBuilder(shape, name, rootModuleName)
                 .definitionFile("./api_types.go")
                 .build();
     }
@@ -223,7 +223,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol unionShape(UnionShape shape) {
         // TODO: implement unions
-        return createSymbolBuilder(shape, "nil").build();
+        return createPointableSymbolBuilder(shape, "nil").build();
     }
 
     @Override
@@ -235,23 +235,25 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol timestampShape(TimestampShape shape) {
-        return createSymbolBuilder(shape, "time.Time")
+        return createPointableSymbolBuilder(shape, "time.Time")
                 .addReference(createNamespaceReference(GoDependency.TIME))
                 .build();
     }
 
-    private Symbol.Builder createSymbolBuilder(Shape shape, String typeName, boolean pointable) {
+    private Symbol.Builder createSymbolBuilder(Shape shape, String typeName) {
         return Symbol.builder().putProperty("shape", shape)
-                .putProperty("pointable", pointable)
+                .putProperty("pointable", false)
                 .name(typeName);
     }
 
-    private Symbol.Builder createSymbolBuilder(Shape shape, String typeName) {
-        return createSymbolBuilder(shape, typeName, true);
+    private Symbol.Builder createPointableSymbolBuilder(Shape shape, String typeName) {
+        return Symbol.builder().putProperty("shape", shape)
+                .putProperty("pointable", true)
+                .name(typeName);
     }
 
-    private Symbol.Builder createSymbolBuilder(Shape shape, String typeName, String namespace) {
-        return createSymbolBuilder(shape, typeName).namespace(namespace, ".");
+    private Symbol.Builder createPointableSymbolBuilder(Shape shape, String typeName, String namespace) {
+        return createPointableSymbolBuilder(shape, typeName).namespace(namespace, ".");
     }
 
     private SymbolReference createNamespaceReference(GoDependency dependency) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -100,12 +100,12 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol blobShape(BlobShape shape) {
-        return createSymbolBuilder(shape, "[]byte").build();
+        return createSymbolBuilder(shape, "[]byte", false).build();
     }
 
     @Override
     public Symbol booleanShape(BooleanShape shape) {
-        return createSymbolBuilder(shape, "*bool").build();
+        return createSymbolBuilder(shape, "bool").build();
     }
 
     @Override
@@ -123,7 +123,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     private Symbol createCollectionSymbol(CollectionShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return createSymbolBuilder(shape, "[]" + reference.getName())
+        return createSymbolBuilder(shape, "[]" + reference.getName(), false)
                 .addReference(reference)
                 .build();
     }
@@ -131,34 +131,34 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol mapShape(MapShape shape) {
         Symbol reference = toSymbol(shape.getValue());
-        return createSymbolBuilder(shape, "map[string]" + reference.getName())
+        return createSymbolBuilder(shape, "map[string]" + reference.getName(), false)
                 .addReference(reference)
                 .build();
     }
 
     @Override
     public Symbol byteShape(ByteShape shape) {
-        return createSymbolBuilder(shape, "*byte").build();
+        return createSymbolBuilder(shape, "byte").build();
     }
 
     @Override
     public Symbol shortShape(ShortShape shape) {
-        return createSymbolBuilder(shape, "*int16").build();
+        return createSymbolBuilder(shape, "int16").build();
     }
 
     @Override
     public Symbol integerShape(IntegerShape shape) {
-        return createSymbolBuilder(shape, "*int32").build();
+        return createSymbolBuilder(shape, "int32").build();
     }
 
     @Override
     public Symbol longShape(LongShape shape) {
-        return createSymbolBuilder(shape, "*int64").build();
+        return createSymbolBuilder(shape, "int64").build();
     }
 
     @Override
     public Symbol floatShape(FloatShape shape) {
-        return createSymbolBuilder(shape, "*float32").build();
+        return createSymbolBuilder(shape, "float32").build();
     }
 
     @Override
@@ -169,17 +169,17 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol doubleShape(DoubleShape shape) {
-        return createSymbolBuilder(shape, "*float64").build();
+        return createSymbolBuilder(shape, "float64").build();
     }
 
     @Override
     public Symbol bigIntegerShape(BigIntegerShape shape) {
-        return createBigSymbol(shape, "*big.Int");
+        return createBigSymbol(shape, "big.Int");
     }
 
     @Override
     public Symbol bigDecimalShape(BigDecimalShape shape) {
-        return createBigSymbol(shape, "*big.Float");
+        return createBigSymbol(shape, "big.Float");
     }
 
     private Symbol createBigSymbol(Shape shape, String symbolName) {
@@ -209,7 +209,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol stringShape(StringShape shape) {
         // TODO: support specialized strings
-        return createSymbolBuilder(shape, "*string").build();
+        return createSymbolBuilder(shape, "string").build();
     }
 
     @Override
@@ -235,13 +235,19 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol timestampShape(TimestampShape shape) {
-        return createSymbolBuilder(shape, "*time.Time")
+        return createSymbolBuilder(shape, "time.Time")
                 .addReference(createNamespaceReference(GoDependency.TIME))
                 .build();
     }
 
+    private Symbol.Builder createSymbolBuilder(Shape shape, String typeName, boolean pointable) {
+        return Symbol.builder().putProperty("shape", shape)
+                .putProperty("pointable", pointable)
+                .name(typeName);
+    }
+
     private Symbol.Builder createSymbolBuilder(Shape shape, String typeName) {
-        return Symbol.builder().putProperty("shape", shape).name(typeName);
+        return createSymbolBuilder(shape, typeName, true);
     }
 
     private Symbol.Builder createSymbolBuilder(Shape shape, String typeName, String namespace) {


### PR DESCRIPTION
This adds dependency support and support for timestamps, big ints, and big decimals. The generated test package's types now looks like:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

import (
	"time"
)

type CityCoordinates struct {
	Latitude  *float32
	Longitude *float32
}

type CitySummary struct {
	Case   *string
	CityId *string
	Name   *string
	Number *string
}

type GetCityImageInput struct {
	CityId *string
}

type GetCityImageOutput struct {
	Image []byte
}

type GetCityInput struct {
	CityId *string
}

type GetCityOutput struct {
	City        *CitySummary
	Coordinates *CityCoordinates
	Name        *string
}

type GetCurrentTimeOutput struct {
	Time *time.Time
}

type GetForecastInput struct {
	CityId *string
}

type GetForecastOutput struct {
	ChanceOfRain *float32
}

type ListCitiesInput struct {
	NextToken *string
	PageSize  *int32
}

type ListCitiesOutput struct {
	Items     []CitySummary
	NextToken *string
}
```

Additionally, `go mod edit -require` will be called for any dependency outside of the standard library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
