### PR TITLE
Introduce document type support

### DIFF
--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -1,4 +1,9 @@
 $version: "0.5.0"
+
+metadata suppressions = [{
+    ids: ["UnstableFeature"],
+}]
+
 namespace example.weather
 
 /// Provides weather forecasts.
@@ -58,7 +63,11 @@ structure GetCityOutput {
     coordinates: CityCoordinates,
 
     city: CitySummary,
+
+    metadata: CityMetadata
 }
+
+document CityMetadata
 
 // This structure is nested within GetCityOutput.
 structure CityCoordinates {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -74,12 +74,11 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         List<SymbolDependency> dependencies = writers.getDependencies();
         writers.flushWriters();
 
-        LOGGER.fine("Generating go.mod file");
-        GoModGenerator.writeGoMod(settings, fileManifest, SymbolDependency.gatherDependencies(dependencies.stream()));
-
-
         LOGGER.fine("Running go fmt");
         CodegenUtils.runCommand("go fmt", fileManifest.getBaseDir());
+
+        LOGGER.fine("Generating go.mod file");
+        GoModGenerator.writeGoMod(settings, fileManifest, SymbolDependency.gatherDependencies(dependencies.stream()));
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -29,7 +29,9 @@ public enum GoDependency implements SymbolDependencyContainer {
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
     BIG("stdlib", "math/big", "1.14"),
-    TIME("stdlib", "time", "1.14");
+    TIME("stdlib", "time", "1.14"),
+
+    SMITHY("dependency", "github.com/awslabs/smithy-go", "v0.0.1");
 
     public final String packageName;
     public final String version;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -181,8 +181,9 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        // TODO: implement document shapes
-        return createPointableSymbolBuilder(shape, "nil").build();
+        return createPointableSymbolBuilder(shape, "smithy.Document")
+                .addReference(createNamespaceReference(GoDependency.SMITHY, "smithy"))
+                .build();
     }
 
     @Override
@@ -285,6 +286,11 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private SymbolReference createNamespaceReference(GoDependency dependency) {
+        String namespace = dependency.getDependencies().get(0).getPackageName();
+        return createNamespaceReference(dependency, CodegenUtils.getDefaultPackageImportName(namespace));
+    }
+
+    private SymbolReference createNamespaceReference(GoDependency dependency, String alias) {
         // Go generally imports an entire package under a single name, which defaults to the last
         // part of the package name path. So we need to create a symbol for that namespace to reference.
         String namespace = dependency.getDependencies().get(0).getPackageName();
@@ -297,7 +303,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 .build();
         return SymbolReference.builder()
                 .symbol(namespaceSymbol)
-                .alias(CodegenUtils.getDefaultPackageImportName(namespace))
+                .alias(alias)
                 .build();
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -181,7 +181,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        return createPointableSymbolBuilder(shape, "smithy.Document")
+        return createSymbolBuilder(shape, "smithy.Document")
                 .addReference(createNamespaceReference(GoDependency.SMITHY, "smithy"))
                 .build();
     }

--- a/document.go
+++ b/document.go
@@ -1,0 +1,52 @@
+package smithy
+
+// A document type represents an untyped JSON-like value.
+//
+// Not all protocols support document types, and the serialization format of a
+// document type is protocol specific. All JSON protocols SHOULD support
+// document types and they SHOULD serialize document types inline as normal
+// JSON values.
+type Document interface {
+	// Marshal will attempt to serialize the provided type into a
+	// protocol specific document value.
+	Marshal(x interface{}) error
+
+	// Unmarshall will attempt to map the protocol specific document value
+	// onto the provided type. If the type does not match the document type
+	// an error will be returned.
+	Unmarshal(x interface{}) error
+
+	// Indicates the document is a null (nil) type.
+	IsNull() bool
+
+	// Indicates the document is a boolean (bool) type.
+	IsBoolean() bool
+
+	// Indicates the document is a string type.
+	IsString() bool
+
+	// Indicates the document is a byte type.
+	IsByte() bool
+
+	// Indicates the document is a short (int16) type.
+	IsShort() bool
+
+	// Indicates the document is an integer (int32) type.
+	IsInteger() bool
+
+	// Indicates the document is a long (int64) type.
+	IsLong() bool
+
+	// Indicates the document is a float (float32) type.
+	IsFloat() bool
+
+	// Indicates the document is a double (float64) type.
+	IsDouble() bool
+
+	// Indicates the document is an array.
+	IsArray() bool
+
+	// Indicates the document is a map. Keys for document maps MUST be
+	// strings.
+	IsMap() bool
+}

--- a/document.go
+++ b/document.go
@@ -9,12 +9,12 @@ package smithy
 type Document interface {
 	// Marshal will attempt to serialize the provided type into a
 	// protocol specific document value.
-	Marshal(x interface{}) error
+	MarshalDocument(x interface{}) error
 
 	// Unmarshall will attempt to map the protocol specific document value
 	// onto the provided type. If the type does not match the document type
 	// an error will be returned.
-	Unmarshal(x interface{}) error
+	UnmarshalDocument(x interface{}) error
 
 	// Indicates the document is a null (nil) type.
 	IsNull() bool


### PR DESCRIPTION
*Description of changes:*

This introduces an interface for document types, and ensures that their symbols are generated. A document type was introduced into the sample model for demonstrative purposes:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

import (
	smithy "github.com/awslabs/smithy-go"
	"time"
)

type CityCoordinates struct {
	Latitude  *float32
	Longitude *float32
}

type CitySummary struct {
	Case   *string
	CityId *string
	Name   *string
	Number *string
}

type GetCityImageInput struct {
	CityId *string
}

type GetCityImageOutput struct {
	Image []byte
}

type GetCityInput struct {
	CityId *string
}

type GetCityOutput struct {
	City        *CitySummary
	Coordinates *CityCoordinates
	Metadata    smithy.Document
	Name        *string
}

type GetCurrentTimeOutput struct {
	Time *time.Time
}

type GetForecastInput struct {
	CityId *string
}

type GetForecastOutput struct {
	ChanceOfRain *float32
}

type ListCitiesInput struct {
	NextToken *string
	PageSize  *int32
}

type ListCitiesOutput struct {
	Items     []CitySummary
	NextToken *string
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
