### PR TITLE
Introduce MediaType support

### DIFF
--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -58,7 +58,12 @@ structure GetCityOutput {
     coordinates: CityCoordinates,
 
     city: CitySummary,
+
+    cityPicture: JpegImage,
 }
+
+@mediaType("image/jpeg")
+blob JpegImage
 
 // This structure is nested within GetCityOutput.
 structure CityCoordinates {

--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -58,12 +58,7 @@ structure GetCityOutput {
     coordinates: CityCoordinates,
 
     city: CitySummary,
-
-    cityPicture: JpegImage,
 }
-
-@mediaType("image/jpeg")
-blob JpegImage
 
 // This structure is nested within GetCityOutput.
 structure CityCoordinates {
@@ -201,4 +196,5 @@ structure GetCityImageOutput {
     image: CityImageData,
 }
 
+@mediaType("image/jpeg")
 blob CityImageData

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -25,10 +25,13 @@ import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
 
 /**
  * Orchestrates Go client generation.
@@ -87,5 +90,25 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
     public Void structureShape(StructureShape shape) {
         writers.useShapeWriter(shape, writer -> new StructureGenerator(model, symbolProvider, writer, shape).run());
         return null;
+    }
+
+    @Override
+    public Void stringShape(StringShape shape) {
+        if (shape.hasTrait(MediaTypeTrait.class)) {
+            generateMediaType(shape);
+        }
+        return null;
+    }
+
+    @Override
+    public Void blobShape(BlobShape shape) {
+        if (shape.hasTrait(MediaTypeTrait.class)) {
+            generateMediaType(shape);
+        }
+        return null;
+    }
+
+    private void generateMediaType(Shape shape) {
+        writers.useShapeWriter(shape, writer -> new MediaTypeGenerator(symbolProvider, writer, shape).run());
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/MediaTypeGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/MediaTypeGenerator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
+
+/**
+ * Renders media type shapes with their associated methods.
+ */
+final class MediaTypeGenerator implements Runnable {
+
+    private final SymbolProvider symbolProvider;
+    private final GoWriter writer;
+    private final Shape shape;
+
+    MediaTypeGenerator(SymbolProvider symbolProvider, GoWriter writer, Shape shape) {
+        this.symbolProvider = symbolProvider;
+        this.writer = writer;
+        this.shape = shape;
+    }
+
+    @Override
+    public void run() {
+        Symbol symbol = symbolProvider.toSymbol(shape);
+
+        Symbol baseType = symbol.getProperty("mediaTypeBaseSymbol", Symbol.class)
+                .orElseThrow(() -> new CodegenException(
+                        "Media type symbols must have the property mediaTypeBaseSymbol: " + shape.getId()));
+
+        writer.write("type $L $T", symbol.getName(), baseType)
+                .write("")
+                .openBlock("func (m $L) MediaType() string {", "}", symbol.getName(), () -> {
+                    writer.write("return $S", shape.expectTrait(MediaTypeTrait.class).getValue());
+                })
+                .write("");
+    }
+}

--- a/mediatype.go
+++ b/mediatype.go
@@ -1,0 +1,9 @@
+package smithy
+
+// The MediaType interface is intended to be implemented by string and
+// byte array types whose values can be defined by RFC638 media types.
+type MediaType interface {
+	// Describes the contents of the string or byte array using a media type
+	// as defined by RFC6838.
+	MediaType() string
+}


### PR DESCRIPTION
*Description of changes:*

This introduces an interface for media types, and generates types for shapes that use them. A string or byte array can have a `MediaType()` function that returns its media type, which is defined in an interface in the base package. Currently there's no special handling for any particular media type.

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

import (
	"time"
)

type CityCoordinates struct {
	Latitude  *float32
	Longitude *float32
}

type CityImageData []byte

func (m CityImageData) MediaType() string {
	return "image/jpeg"
}

type CitySummary struct {
	Case   *string
	CityId *string
	Name   *string
	Number *string
}

type GetCityImageInput struct {
	CityId *string
}

type GetCityImageOutput struct {
	Image *CityImageData
}

type GetCityInput struct {
	CityId *string
}

type GetCityOutput struct {
	City        *CitySummary
	Coordinates *CityCoordinates
	Name        *string
}

type GetCurrentTimeOutput struct {
	Time *time.Time
}

type GetForecastInput struct {
	CityId *string
}

type GetForecastOutput struct {
	ChanceOfRain *float32
}

type ListCitiesInput struct {
	NextToken *string
	PageSize  *int32
}

type ListCitiesOutput struct {
	Items     []CitySummary
	NextToken *string
}
```

Right now each shape is getting its own new type, with no de-duplication. We *could* try to condense it down to something like one generated `MediaTypeApplicationJSON` for all `application/json` etc, but it doesn't seem necessary and it introduces complexity that we may not want. Plugins will, eventually, be able to decorate the shape writer so they can add in decoding methods.

[working sample](https://play.golang.org/p/50mzFb6PgRU)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
