### PR TITLE
Generate enums

### DIFF
--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -151,6 +151,7 @@ structure GetForecastInput {
 
 structure GetForecastOutput {
     chanceOfRain: Float,
+    precipitation: Precipitation,
 }
 
 union Precipitation {
@@ -169,7 +170,7 @@ structure OtherStructure {}
 @enum("YES": {}, "NO": {})
 string SimpleYesNo
 
-@enum("YES": {name: "YES"}, "NO": {name: "NO"})
+@enum("Yes": {name: "YES"}, "No": {name: "NO"})
 string TypedYesNo
 
 map StringMap {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 
 /**
@@ -94,7 +95,9 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     @Override
     public Void stringShape(StringShape shape) {
-        if (shape.hasTrait(MediaTypeTrait.class)) {
+        if (shape.hasTrait(EnumTrait.class)) {
+            writers.useShapeWriter(shape, writer -> new EnumGenerator(symbolProvider, writer, shape).run());
+        } else if (shape.hasTrait(MediaTypeTrait.class)) {
             generateMediaType(shape);
         }
         return null;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Locale;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Renders enums and their constants.
+ */
+final class EnumGenerator implements Runnable {
+
+    private final SymbolProvider symbolProvider;
+    private final GoWriter writer;
+    private final StringShape shape;
+
+    EnumGenerator(SymbolProvider symbolProvider, GoWriter writer, StringShape shape) {
+        this.symbolProvider = symbolProvider;
+        this.writer = writer;
+        this.shape = shape;
+    }
+
+    @Override
+    public void run() {
+        Symbol symbol = symbolProvider.toSymbol(shape);
+        EnumTrait enumTrait = shape.expectTrait(EnumTrait.class);
+
+        writer.write("type $L string", symbol.getName()).write("");
+
+        writer.write("// Enum values for $L", symbol.getName()).openBlock("const (", ")", () -> {
+            for (Map.Entry<String, EnumConstantBody> entry : enumTrait.getValues().entrySet()) {
+                StringBuilder labelBuilder = new StringBuilder(symbol.getName());
+                String name = entry.getValue().getName().orElse(entry.getKey());
+                for (String part : name.split("\\W")) {
+                    labelBuilder.append(StringUtils.capitalize(part.toLowerCase(Locale.US)));
+                }
+                String label = labelBuilder.toString();
+                writer.write("$L $L = $S", label, symbol.getName(), entry.getKey());
+            }
+        }).write("");
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
@@ -50,7 +50,7 @@ final class EnumGenerator implements Runnable {
             for (Map.Entry<String, EnumConstantBody> entry : enumTrait.getValues().entrySet()) {
                 StringBuilder labelBuilder = new StringBuilder(symbol.getName());
                 String name = entry.getValue().getName().orElse(entry.getKey());
-                for (String part : name.split("\\W")) {
+                for (String part : name.split("(?U)\\W")) {
                     labelBuilder.append(StringUtils.capitalize(part.toLowerCase(Locale.US)));
                 }
                 String label = labelBuilder.toString();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -49,6 +49,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -225,7 +226,13 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol stringShape(StringShape shape) {
-        // TODO: enums
+        if (shape.hasTrait(EnumTrait.class)) {
+            String name = StringUtils.capitalize(shape.getId().getName());
+            return createPointableSymbolBuilder(shape, name, rootModuleName)
+                    .definitionFile("./api_enums.go")
+                    .build();
+        }
+
         Symbol stringSymbol = createPointableSymbolBuilder(shape, "string").build();
         if (shape.hasTrait(MediaTypeTrait.class)) {
             return createMediaTypeSymbol(shape, stringSymbol);


### PR DESCRIPTION
*Description of changes:*

This introduces enum generation. Enums are generated into `api_enums.go`, like so:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

type SimpleYesNo string

// Enum values for SimpleYesNo
const (
	SimpleYesNoYes SimpleYesNo = "YES"
	SimpleYesNoNo  SimpleYesNo = "NO"
)

type TypedYesNo string

// Enum values for TypedYesNo
const (
	TypedYesNoYes TypedYesNo = "Yes"
	TypedYesNoNo  TypedYesNo = "No"
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
