### PR TITLE
Emit an io.Reader for streaming blobs

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -29,6 +29,7 @@ public enum GoDependency implements SymbolDependencyContainer {
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
     BIG("stdlib", "math/big", "1.14"),
+    IO("stdlib", "io", "1.14"),
     TIME("stdlib", "time", "1.14");
 
     public final String packageName;


### PR DESCRIPTION
This updates blobs with the `streaming` trait to `io.Reader` instead of `[]byte`. They'll now look like:

```go
import (
	"io"
)

type MyStruct struct {
	StreamingBlob io.Reader
}
```

Or if they have the `mediatype` trait too:

```go
import (
	"io"
)

type CityImageData io.Reader

func (m CityImageData) MediaType() string {
	return "image/jpeg"
}
```

Note that this PR is dependent on [this Smithy change](https://github.com/awslabs/smithy/pull/340). This PR is still merge-able. It'll run, but the code path is effectively dead until the Smithy PR is merged and this generator updates to that version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
