### PR TITLE
Add Smithy APIError base and wrapping error types

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,82 @@
+package smithy
+
+import "fmt"
+
+// APIError provides the generic API and protocol agnostic error type all SDK
+// generated exception types will implement.
+type APIError interface {
+	error
+
+	// ErrorCode returns the error code for the API exception.
+	ErrorCode() string
+	// ErrorMessage returns the error message for the API exception.
+	ErrorMessage() string
+	// ErrorFault returns the fault for the API exception.
+	ErrorFault() ErrorFault
+}
+
+// GenericAPIError provides a generic concrete API error type that SDKs can use
+// to deserialize error responses into. Should be used for unmodeled or untyped
+// errors.
+type GenericAPIError struct {
+	Code    string
+	Message string
+	Fault   ErrorFault
+}
+
+// ErrorCode returns the error code for the API exception.
+func (e *GenericAPIError) ErrorCode() string { return e.Code }
+
+// ErrorMessage returns the error message for the API exception.
+func (e *GenericAPIError) ErrorMessage() string { return e.Message }
+
+// ErrorFault returns the fault for the API exception.
+func (e *GenericAPIError) ErrorFault() ErrorFault { return e.Fault }
+
+func (e *GenericAPIError) Error() string {
+	return fmt.Sprintf("api error %s: %s", e.Code, e.Message)
+}
+
+var _ APIError = (*GenericAPIError)(nil)
+
+// OperationError decorates an underlying error which occurred while invoking
+// an operation with names of the operation and API.
+type OperationError struct {
+	ServiceName   string
+	OperationName string
+	Err           error
+}
+
+// Service returns the name of the API service the error occurred with.
+func (e *OperationError) Service() string { return e.ServiceName }
+
+// Operation returns the name of the API operation the error occurred with.
+func (e *OperationError) Operation() string { return e.OperationName }
+
+// Unwrap returns the nested error if any, or nil.
+func (e *OperationError) Unwrap() error { return e.Err }
+
+func (e *OperationError) Error() string {
+	return fmt.Sprintf("operation error %s: %s, %v", e.ServiceName, e.OperationName, e.Err)
+}
+
+// ErrorFault provides the type for a Smithy API error fault.
+type ErrorFault int
+
+// ErrorFault enumeration values
+const (
+	FaultUnknown ErrorFault = iota
+	FaultServer
+	FaultClient
+)
+
+func (f ErrorFault) String() string {
+	switch f {
+	case FaultServer:
+		return "server"
+	case FaultClient:
+		return "client"
+	default:
+		return "unknown"
+	}
+}

--- a/fault.go
+++ b/fault.go
@@ -1,0 +1,1 @@
+package smithy

--- a/fault.go
+++ b/fault.go
@@ -1,1 +1,0 @@
-package smithy

--- a/middleware/step_deserialize.go
+++ b/middleware/step_deserialize.go
@@ -1,6 +1,8 @@
 package middleware
 
-import "context"
+import (
+	"context"
+)
 
 // DeserializeInput provides the input parameters for the DeserializeInput to
 // consume. DeserializeMiddleware should not modify the Request, and instead

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -165,7 +165,7 @@ func (w finalizeWrapHandler) HandleFinalize(ctx context.Context, in FinalizeInpu
 	res, metadata, err := w.Next.Handle(ctx, in.Request)
 	return FinalizeOutput{
 		Result: res,
-	}, metadata, nil
+	}, metadata, err
 }
 
 type decoratedFinalizeHandler struct {

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -112,7 +112,7 @@ func (s *InitializeStep) HandleMiddleware(ctx context.Context, in interface{}, n
 	}
 
 	res, metadata, err := h.HandleInitialize(ctx, sIn)
-	return res.Result, metadata, nil
+	return res.Result, metadata, err
 }
 
 // Add injects the middleware to the relative position of the middleware group.
@@ -165,7 +165,7 @@ func (w initializeWrapHandler) HandleInitialize(ctx context.Context, in Initiali
 	res, metadata, err := w.Next.Handle(ctx, in.Parameters)
 	return InitializeOutput{
 		Result: res,
-	}, metadata, nil
+	}, metadata, err
 }
 
 type decoratedInitializeHandler struct {

--- a/middleware/step_serialize.go
+++ b/middleware/step_serialize.go
@@ -173,7 +173,7 @@ func (w serializeWrapHandler) HandleSerialize(ctx context.Context, in SerializeI
 	res, metadata, err := w.Next.Handle(ctx, in.Request)
 	return SerializeOutput{
 		Result: res,
-	}, metadata, nil
+	}, metadata, err
 }
 
 type decoratedSerializeHandler struct {

--- a/transport/http/response.go
+++ b/transport/http/response.go
@@ -1,9 +1,31 @@
 package http
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 // Response provides the HTTP specific response structure for HTTP specific
 // middleware steps to use to deserialize the response from an operation call.
 type Response struct {
 	*http.Response
+}
+
+// ResponseError provides the HTTP centric error type wrapping the underlying
+// error with the HTTP response value.
+type ResponseError struct {
+	Response *Response
+	Err      error
+}
+
+// HTTPResponse returns the HTTP response received from the service.
+func (e *ResponseError) HTTPResponse() *Response { return e.Response }
+
+// Unwrap returns the nested error if any, or nil.
+func (e *ResponseError) Unwrap() error { return e.Err }
+
+func (e *ResponseError) Error() string {
+	return fmt.Sprintf(
+		"http response error StatusCode: %d, %v",
+		e.Response.StatusCode, e.Err)
 }

--- a/transport/http/response_error_example_test.go
+++ b/transport/http/response_error_example_test.go
@@ -1,0 +1,114 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/awslabs/smithy-go"
+	"github.com/awslabs/smithy-go/middleware"
+)
+
+func ExampleResponseError() {
+	stack := middleware.NewStack("my cool stack", NewStackRequest)
+
+	stack.Deserialize.Add(middleware.DeserializeMiddlewareFunc("wrap http response error",
+		func(ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler) (
+			out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+		) {
+			out, metadata, err = next.HandleDeserialize(ctx, in)
+			if err == nil {
+				// Nothing to do when there is no error.
+				return out, metadata, err
+			}
+
+			rawResp, ok := out.RawResponse.(*Response)
+			if !ok {
+				// No raw response to wrap with.
+				return out, metadata, err
+			}
+
+			// Wrap the returned error with the response error containing the
+			// returned response.
+			err = &ResponseError{
+				Response: rawResp,
+				Err:      err,
+			}
+
+			return out, metadata, err
+		}),
+		middleware.After,
+	)
+
+	stack.Deserialize.Add(middleware.DeserializeMiddlewareFunc("deserialize error",
+		func(ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler) (
+			out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+		) {
+			out, metadata, err = next.HandleDeserialize(ctx, in)
+			if err != nil {
+				return middleware.DeserializeOutput{}, metadata, err
+			}
+
+			rawResp := out.RawResponse.(*Response)
+			if rawResp.StatusCode == 200 {
+				return out, metadata, nil
+			}
+
+			// Deserialize the response API error values.
+			err = &smithy.GenericAPIError{
+				Code:    rawResp.Header.Get("Error-Code"),
+				Message: rawResp.Header.Get("Error-Message"),
+			}
+
+			return out, metadata, err
+		}),
+		middleware.After,
+	)
+
+	// Mock example handler taking the request input and returning a response
+	mockHandler := middleware.HandlerFunc(func(ctx context.Context, in interface{}) (
+		output interface{}, metadata middleware.Metadata, err error,
+	) {
+		// populate the mock response with an API error and additional data.
+		resp := &http.Response{
+			StatusCode: 404,
+			Header: http.Header{
+				"Extra-Header":  []string{"foo value"},
+				"Error-Code":    []string{"FooException"},
+				"Error-Message": []string{"some message about the error"},
+			},
+		}
+
+		// The handler's returned response will be available as the
+		// DeserializeOutput.RawResponse field.
+		return &Response{
+			Response: resp,
+		}, middleware.NewMetadata(), nil
+	})
+
+	// Use the stack to decorate the handler then invoke the decorated handler
+	// with the inputs.
+	handler := middleware.DecorateHandler(mockHandler, stack)
+	_, _, err := handler.Handle(context.Background(), struct{}{})
+	if err == nil {
+		fmt.Printf("expect error, got none")
+		return
+	}
+
+	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) {
+			fmt.Printf("request failed: %s, %s\n", apiErr.ErrorCode(), apiErr.ErrorMessage())
+		}
+
+		var respErr *ResponseError
+		if errors.As(err, &respErr) {
+			fmt.Printf("response header: %v\n", respErr.HTTPResponse().Header.Get("Extra-Header"))
+		}
+	}
+
+	// Output:
+	// request failed: FooException, some message about the error
+	// response header: foo value
+}


### PR DESCRIPTION
Adds the base error and metadata wrapping error types that Smithy SDKs will use to compose APIErrors received from API responses with additional metadata.

Smithy generated SDK API errors will implement a common smithy APIError interface. This interface provides generic accessor methods that all generated client API errors, will implement. Metadata about the operation, response, retry, etc will all be provided by error types
wrapping the returned APIError value. This allows the SDK to use errors across multiple protocols like HTTP and event stream without additional noise. This approach also protects the SDK against additional metadata fields being added to the chain forcing the SDK to use either optional interfaces, or breaking change to expose the new metadata.

Layering errors this way acts similar to the mix-in design pattern. Each layer provides additional metadata describing not just the error but the path it took to come back to the user.

Example of using the API errors with this design.

```go
result, err := client.GetObject(ctx, params)
if err != nil {
    var apiErr smithy.APIError
    if errors.As(err, &apiErr) {
        fmt.Printf("request failed: %s, %s\n", apiErr.ErrorCode(), apiErr.ErrorMessage())
    }

    var respErr *smithyhttp.ResponseError
    if errors.As(err, &respErr) {
        fmt.Printf("response header: %v\n", respErr.HTTPResponse().Header.Get("Extra-Header"))
    }
}
```