### PR TITLE
Update middleware Metadata to be a struct instead of interface

### DIFF
--- a/middleware/metadata.go
+++ b/middleware/metadata.go
@@ -1,50 +1,52 @@
 package middleware
 
-// Metadata provides an interface for storing and reading metadata values. Keys
-// may be any comparable value type. Get and set will panic if key is not a
-// comparable value type.
-type Metadata interface {
-	Get(key interface{}) interface{}
-	Set(Key, value interface{})
-}
-
 // MetadataReader provides an interface for reading metadata from the
 // underlying metadata container.
 type MetadataReader interface {
 	Get(key interface{}) interface{}
 }
 
-// NewMetadata returns an initialized value for storing metadata on.
-func NewMetadata() Metadata {
-	return &metadata{
-		values: map[interface{}]interface{}{},
-	}
-}
-
-type metadata struct {
+// Metadata provides storing and reading metadata values. Keys may be any
+// comparable value type. Get and set will panic if key is not a comparable
+// value type.
+//
+// Metadata uses lazy initialization, and Set method must be called as an
+// addressable value, or pointer. Not doing so may cause key/value pair to not
+// be set.
+type Metadata struct {
 	values map[interface{}]interface{}
 }
 
 // Get attempts to retrieve the value the key points to. Returns nil if the
 // key was not found.
 //
-//Panics if key type is not comparable.
-func (m *metadata) Get(key interface{}) interface{} {
+// Panics if key type is not comparable.
+func (m Metadata) Get(key interface{}) interface{} {
 	return m.values[key]
 }
 
 // Set stores the value pointed to by the key. If a value already exists at
 // that key it will be replaced with the new value.
 //
+// Set method must be called as an addressable value, or pointer. If Set is not
+// called as a addressable value or pointer, the key value pair being set may
+// be lost.
+//
 // Panics if the key type is not comparable.
-func (m *metadata) Set(key, value interface{}) {
+func (m *Metadata) Set(key, value interface{}) {
+	if m.values == nil {
+		m.values = map[interface{}]interface{}{}
+	}
 	m.values[key] = value
 }
 
 // Has returns if the key exists in the metadata.
 //
 // Panics if the key type is not comparable.
-func (m *metadata) Has(key interface{}) bool {
+func (m Metadata) Has(key interface{}) bool {
+	if m.values == nil {
+		return false
+	}
 	_, ok := m.values[key]
 	return ok
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -23,9 +23,24 @@ func (m mockMiddleware) HandleMiddleware(ctx context.Context, input interface{},
 ) {
 	output, metadata, err = next.Handle(ctx, input)
 
-	metadata.Set(fmt.Sprintf("foo-%d", m.id), fmt.Sprintf("mock-%d", m.id))
+	mockKeySet(&metadata, m.id, fmt.Sprintf("mock-%d", m.id))
 
 	return output, metadata, err
+}
+
+type mockKey struct{ Key int }
+
+func mockKeySet(md *Metadata, key int, val string) {
+	md.Set(mockKey{Key: key}, val)
+}
+
+func mockKeyGet(md MetadataReader, key int) string {
+	v := md.Get(mockKey{Key: key})
+	if v == nil {
+		return ""
+	}
+
+	return v.(string)
 }
 
 type mockHandler struct {
@@ -36,7 +51,7 @@ func (m *mockHandler) Handle(ctx context.Context, input interface{}) (
 	output interface{}, metadata Metadata, err error,
 ) {
 	m.calledMiddleware = GetMiddlewareIDs(ctx)
-	return nil, NewMetadata(), nil
+	return nil, metadata, nil
 }
 
 func TestDecorateHandler(t *testing.T) {
@@ -66,19 +81,15 @@ func TestDecorateHandler(t *testing.T) {
 		t.Errorf("expect:\n%v\nactual:\n%v", e, a)
 	}
 
-	expectMeta := map[string]interface{}{
-		"foo-0": "mock-0",
-		"foo-1": "mock-1",
-		"foo-2": "mock-2",
+	expectMeta := map[int]interface{}{
+		0: "mock-0",
+		1: "mock-1",
+		2: "mock-2",
 	}
 
 	for key, expect := range expectMeta {
-		v := metadata.Get(key)
-		_, ok := v.(string)
-		if !ok {
-			t.Fatalf("expect %v to be %T, got %T", key, "", v)
-		}
-		if e, a := expect, v.(string); e != a {
+		v := mockKeyGet(metadata, key)
+		if e, a := expect, v; e != a {
 			t.Errorf("expect %v: %v metadata got %v", key, e, a)
 		}
 	}

--- a/transport/http/deserailize_example_test.go
+++ b/transport/http/deserailize_example_test.go
@@ -62,7 +62,7 @@ func ExampleResponse_deserializeMiddleware() {
 		// DeserializeOutput.RawResponse field.
 		return &Response{
 			Response: resp,
-		}, middleware.NewMetadata(), nil
+		}, metadata, nil
 	})
 
 	// Use the stack to decorate the handler then invoke the decorated handler

--- a/transport/http/response_error_example_test.go
+++ b/transport/http/response_error_example_test.go
@@ -84,7 +84,7 @@ func ExampleResponseError() {
 		// DeserializeOutput.RawResponse field.
 		return &Response{
 			Response: resp,
-		}, middleware.NewMetadata(), nil
+		}, metadata, nil
 	})
 
 	// Use the stack to decorate the handler then invoke the decorated handler

--- a/transport/http/serialize_example_test.go
+++ b/transport/http/serialize_example_test.go
@@ -52,7 +52,7 @@ func ExampleRequest_serializeMiddleware() {
 				StatusCode: 200,
 				Header:     http.Header{},
 			},
-		}, middleware.NewMetadata(), nil
+		}, metadata, nil
 	})
 
 	// Use the stack to decorate the handler then invoke the decorated handler


### PR DESCRIPTION
Updates the middleware Metadata type to be pass by value as a structure in the middleware instead of interface. This removes the need from middleware writers to use `NewMetadata` each time an error is handled. This does require the helper methods to use the Metadata pointer for
set, and MetadataReader for Gets.