### PR TITLE
Write out shape documentation

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -28,5 +28,6 @@ repositories {
 }
 
 dependencies {
+    implementation("software.amazon.smithy:smithy-aws-traits:1.0.0")
     implementation(project(":smithy-go-codegen"))
 }

--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -163,6 +163,7 @@ structure GetForecastOutput {
     precipitation: Precipitation,
 }
 
+/// Different kinds of preciptation.
 union Precipitation {
     rain: PrimitiveBoolean,
     sleet: PrimitiveBoolean,
@@ -179,7 +180,17 @@ structure OtherStructure {}
 @enum("YES": {}, "NO": {})
 string SimpleYesNo
 
-@enum("Yes": {name: "YES"}, "No": {name: "NO"})
+/// yes or no
+@enum(
+    "Yes": {
+        name: "YES",
+        documentation: "yes",
+    },
+    "No": {
+        name: "NO",
+        documentation: "no",
+    }
+)
 string TypedYesNo
 
 map StringMap {
@@ -201,10 +212,12 @@ structure GetCityImageInput {
 }
 
 structure GetCityImageOutput {
+    /// An image of the city in JPEG format.
     @streaming
     @httpPayload
     image: CityImageData,
 }
 
+/// A JPEG image of a city.
 @mediaType("image/jpeg")
 blob CityImageData

--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -1,4 +1,4 @@
-$version: "0.5.0"
+$version: "1.0.0"
 
 metadata suppressions = [{
     ids: ["UnstableFeature"],
@@ -6,8 +6,10 @@ metadata suppressions = [{
 
 namespace example.weather
 
+use aws.protocols#awsJson1_1
+
 /// Provides weather forecasts.
-@protocols([{name: "aws.rest-json-1.1"}])
+@awsJson1_1
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {
     version: "2006-03-01",
@@ -177,20 +179,22 @@ union Precipitation {
 
 structure OtherStructure {}
 
-@enum("YES": {}, "NO": {})
+@enum([{value: "YES"}, {value: "NO"}])
 string SimpleYesNo
 
 /// yes or no
-@enum(
-    "Yes": {
+@enum([
+    {
+        value: "Yes",
         name: "YES",
         documentation: "yes",
     },
-    "No": {
+    {
+        value: "No",
         name: "NO",
         documentation: "no",
     }
-)
+])
 string TypedYesNo
 
 map StringMap {
@@ -213,11 +217,11 @@ structure GetCityImageInput {
 
 structure GetCityImageOutput {
     /// An image of the city in JPEG format.
-    @streaming
     @httpPayload
     image: CityImageData,
 }
 
 /// A JPEG image of a city.
+@streaming
 @mediaType("image/jpeg")
 blob CityImageData

--- a/codegen/smithy-go-codegen-test/model/more-nesting.smithy
+++ b/codegen/smithy-go-codegen-test/model/more-nesting.smithy
@@ -1,4 +1,4 @@
-$version: "0.5.0"
+$version: "1.0.0"
 namespace example.weather.nested.more
 
 structure Baz {

--- a/codegen/smithy-go-codegen-test/model/nested.smithy
+++ b/codegen/smithy-go-codegen-test/model/nested.smithy
@@ -1,4 +1,4 @@
-$version: "0.5.0"
+$version: "1.0.0"
 namespace example.weather.nested
 
 structure Foo {

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -19,4 +19,6 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:1.0.0")
+    api("com.atlassian.commonmark:commonmark:0.14.0")
+    api("org.jsoup:jsoup:1.13.1")
 }

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -18,5 +18,5 @@ extra["displayName"] = "Smithy :: Go :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:0.9.7")
+    api("software.amazon.smithy:smithy-codegen-core:1.0.0")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Set;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.safety.Whitelist;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Converts commonmark-formatted documentation into godoc format.
+ */
+public final class DocumentationConverter {
+    // godoc only supports text blocks, root-level non-inline code blocks, headers, and links.
+    // This whitelist strips out anything we can't reasonably convert, vastly simplifying the
+    // node tree we end up having to crawl through.
+    private static final Whitelist GODOC_WHITELIST = new Whitelist()
+            .addTags("code", "pre", "ul", "ol", "li", "a", "br", "h1", "h2", "h3", "h4", "h5", "h6")
+            .addAttributes("a", "href")
+            .addProtocols("a", "href", "http", "https", "mailto");
+
+    private DocumentationConverter() {}
+
+    /**
+     * Converts a commonmark formatted string into a godoc formatted string.
+     *
+     * @param docs commonmark formatted documentation
+     * @return godoc formatted documentation
+     */
+    public static String convert(String docs) {
+        // Smithy's documentation format is commonmark, which can inline html. So here we convert
+        // to html so we have a single known format to work with.
+        String htmlDocs = HtmlRenderer.builder().build().render(Parser.builder().build().parse(docs));
+
+        // Strip out tags and attributes we can't reasonably convert to godoc.
+        htmlDocs = Jsoup.clean(htmlDocs, GODOC_WHITELIST);
+
+        // Now we parse the html and visit the resultant nodes to render the godoc.
+        FormattingVisitor formatter = new FormattingVisitor();
+        Node body = Jsoup.parse(htmlDocs).body();
+        NodeTraversor.traverse(formatter, body);
+        return formatter.toString();
+    }
+
+    private static class FormattingVisitor implements NodeVisitor {
+        private static final Set<String> TEXT_BLOCK_NODES = SetUtils.of(
+                "br", "p", "h1", "h2", "h3", "h4", "h5", "h6"
+        );
+        private static final Set<String> LIST_BLOCK_NODES = SetUtils.of("ul", "ol");
+        private static final Set<String> CODE_BLOCK_NODES = SetUtils.of("pre", "code");
+        private final CodeWriter writer;
+
+        private boolean needsListPrefix = false;
+        private boolean shouldStripPrefixWhitespace = false;
+
+        FormattingVisitor() {
+            writer = new CodeWriter();
+            writer.trimTrailingSpaces(false);
+            writer.trimBlankLines();
+            writer.insertTrailingNewline(false);
+        }
+
+        @Override
+        public void head(Node node, int depth) {
+            String name = node.nodeName();
+            if (isTopLevelCodeBlock(node, depth) || LIST_BLOCK_NODES.contains(name)) {
+                writer.indent();
+            }
+
+            if (node instanceof TextNode) {
+                writeText((TextNode) node);
+            } else if (TEXT_BLOCK_NODES.contains(name) || isTopLevelCodeBlock(node, depth)) {
+                writeNewline();
+                writeIndent();
+            } else if (LIST_BLOCK_NODES.contains(name)) {
+                writeNewline();
+            } else if (name.equals("li")) {
+                // We don't actually write out the list prefix here in case the list element
+                // starts with one or more text blocks. By deferring writing those out until
+                // the first bit of actual text, we can ensure that no intermediary newlines
+                // are kept. It also has the added benefit of eliminating empty list elements.
+                needsListPrefix = true;
+            }
+        }
+
+        private void writeNewline() {
+            // While jsoup will strip out redundant whitespace, it will still leave some. If we
+            // start a new line then we want to make sure we don't keep any prefixing whitespace.
+            shouldStripPrefixWhitespace = true;
+            writer.write("");
+        }
+
+        private void writeText(TextNode node) {
+            if (node.isBlank()) {
+                return;
+            }
+
+            // Docs can have valid $ characters that shouldn't run through formatters.
+            String text = node.text().replace("$", "$$");
+
+            if (shouldStripPrefixWhitespace) {
+                shouldStripPrefixWhitespace = false;
+                text = StringUtils.stripStart(text, " \t");
+            }
+
+            if (needsListPrefix) {
+                needsListPrefix = false;
+                writer.write("");
+                writeIndent();
+                text = "* " + StringUtils.stripStart(text, " \t");
+            }
+            writer.writeInline(text);
+        }
+
+        void writeIndent() {
+            writer.setNewline("").write("").setNewline("\n");
+        }
+
+        private boolean isTopLevelCodeBlock(Node node, int depth) {
+            // The node must be a code block node
+            if (!CODE_BLOCK_NODES.contains(node.nodeName())) {
+                return false;
+            }
+
+            // It must either have no siblings or its siblings must be separate blocks.
+            if (!allSiblingsAreBlocks(node)) {
+                return false;
+            }
+
+            // Depth 0 will always be a "body" element, so depth 1 means it's top level.
+            if (depth == 1) {
+                return true;
+            }
+
+            // If its depth is 2, it could still be effectively top level if its parent is a p
+            // node whose siblings are all blocks.
+            Node parent = node.parent();
+            return depth == 2 && parent.nodeName().equals("p") && allSiblingsAreBlocks(parent);
+        }
+
+        /**
+         * Determines whether a given node's siblings are all text blocks, code blocks, or lists.
+         *
+         * <p>Siblings that are blank text nodes are skipped.
+         *
+         * @param node The node whose siblings should be checked.
+         * @return true if the node's siblings are blocks, otherwise false.
+         */
+        private boolean allSiblingsAreBlocks(Node node) {
+            // Find the nearest sibling to the left which is not a blank text node.
+            Node previous = node.previousSibling();
+            while (true) {
+                if (previous instanceof TextNode) {
+                    if (((TextNode) previous).isBlank()) {
+                        previous = previous.previousSibling();
+                        continue;
+                    }
+                }
+                break;
+            }
+
+            // Find the nearest sibling to the right which is not a blank text node.
+            Node next = node.nextSibling();
+            while (true) {
+                if (next instanceof TextNode) {
+                    if (((TextNode) next).isBlank()) {
+                        next = next.nextSibling();
+                        continue;
+                    }
+                }
+                break;
+            }
+
+            return (previous == null || isBlockNode(previous)) && (next == null || isBlockNode(next));
+        }
+
+        private boolean isBlockNode(Node node) {
+            String name = node.nodeName();
+            return TEXT_BLOCK_NODES.contains(name) || LIST_BLOCK_NODES.contains(name)
+                    || CODE_BLOCK_NODES.contains(name);
+        }
+
+        @Override
+        public void tail(Node node, int depth) {
+            String name = node.nodeName();
+            if (isTopLevelCodeBlock(node, depth) || LIST_BLOCK_NODES.contains(name)) {
+                writer.dedent();
+            }
+
+            if (TEXT_BLOCK_NODES.contains(name) || isTopLevelCodeBlock(node, depth)
+                    || LIST_BLOCK_NODES.contains(name)) {
+                writeNewline();
+                writeNewline();
+            } else if (name.equals("a")) {
+                // godoc can't render links with text bodies, so we simply append the link.
+                // Full links do get rendered.
+                writer.writeInline(" ($L)", node.absUrl("href"));
+            } else if (name.equals("li")) {
+                // Clear out the expectation of a list element if the element's body is empty.
+                needsListPrefix = false;
+                writer.write("");
+            }
+        }
+
+        @Override
+        public String toString() {
+            String result = writer.toString();
+            if (StringUtils.isBlank(result)) {
+                return "";
+            }
+
+            // Strip trailing whitespace from every line. We can't use the codewriter for this due to
+            // not knowing when a line will end, as we typically build them up over many elements.
+            String[] lines = result.split("\n", -1);
+            for (int i = 0; i < lines.length; i++) {
+                lines[i] = StringUtils.stripEnd(lines[i], " \t");
+            }
+            result = String.join("\n", lines);
+
+            // Strip any leading blank lines, preserving leading whitespace on the first non-blank line.
+            String[] firstLineSplit = result.split("\n", 2);
+            if (StringUtils.isBlank(firstLineSplit[0])) {
+                return firstLineSplit[1];
+            }
+
+            // Strip out leading and trailing newlines.
+            return StringUtils.strip(result, "\n");
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
@@ -238,12 +238,6 @@ public final class DocumentationConverter {
             }
             result = String.join("\n", lines);
 
-            // Strip any leading blank lines, preserving leading whitespace on the first non-blank line.
-            String[] firstLineSplit = result.split("\n", 2);
-            if (StringUtils.isBlank(firstLineSplit[0])) {
-                return firstLineSplit[1];
-            }
-
             // Strip out leading and trailing newlines.
             return StringUtils.strip(result, "\n");
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
@@ -16,11 +16,10 @@
 package software.amazon.smithy.go.codegen;
 
 import java.util.Locale;
-import java.util.Map;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -47,15 +46,15 @@ final class EnumGenerator implements Runnable {
         writer.write("type $L string", symbol.getName()).write("");
 
         writer.write("// Enum values for $L", symbol.getName()).openBlock("const (", ")", () -> {
-            for (Map.Entry<String, EnumConstantBody> entry : enumTrait.getValues().entrySet()) {
+            for (EnumDefinition definition : enumTrait.getValues()) {
                 StringBuilder labelBuilder = new StringBuilder(symbol.getName());
-                String name = entry.getValue().getName().orElse(entry.getKey());
+                String name = definition.getName().orElse(definition.getValue());
                 for (String part : name.split("(?U)\\W")) {
                     labelBuilder.append(StringUtils.capitalize(part.toLowerCase(Locale.US)));
                 }
                 String label = labelBuilder.toString();
-                entry.getValue().getDocumentation().ifPresent(writer::writeDocs);
-                writer.write("$L $L = $S", label, symbol.getName(), entry.getKey());
+                definition.getDocumentation().ifPresent(writer::writeDocs);
+                writer.write("$L $L = $S", label, symbol.getName(), definition.getValue());
             }
         }).write("");
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EnumGenerator.java
@@ -54,6 +54,7 @@ final class EnumGenerator implements Runnable {
                     labelBuilder.append(StringUtils.capitalize(part.toLowerCase(Locale.US)));
                 }
                 String label = labelBuilder.toString();
+                entry.getValue().getDocumentation().ifPresent(writer::writeDocs);
                 writer.write("$L $L = $S", label, symbol.getName(), entry.getKey());
             }
         }).write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -184,9 +184,7 @@ public final class GoWriter extends CodeWriter {
      * @return Returns the writer.
      */
     public GoWriter writeDocs(String docs) {
-        // Docs can have valid $ characters that shouldn't run through formatters.
-        // Escapes multi-line comment closings.
-        writeDocs(() -> write(docs.replace("$", "$$")));
+        writeDocs(() -> write(DocumentationConverter.convert(docs)));
         return this;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -28,6 +28,10 @@ import software.amazon.smithy.codegen.core.SymbolContainer;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.utils.CodeWriter;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -154,6 +158,67 @@ public final class GoWriter extends CodeWriter {
 
     Collection<SymbolDependency> getDependencies() {
         return dependencies;
+    }
+
+    /**
+     * Writes documentation comments.
+     *
+     * @param runnable Runnable that handles actually writing docs with the writer.
+     * @return Returns the writer.
+     */
+    GoWriter writeDocs(Runnable runnable) {
+        pushState("docs");
+        setNewlinePrefix("// ");
+        runnable.run();
+        setNewlinePrefix("");
+        popState();
+        return this;
+    }
+
+    /**
+     * Writes documentation comments from a string.
+     *
+     * <p>This function escapes "$" characters so formatters are not run.
+     *
+     * @param docs Documentation to write.
+     * @return Returns the writer.
+     */
+    public GoWriter writeDocs(String docs) {
+        // Docs can have valid $ characters that shouldn't run through formatters.
+        // Escapes multi-line comment closings.
+        writeDocs(() -> write(docs.replace("$", "$$")));
+        return this;
+    }
+
+    /**
+     * Writes shape documentation comments if docs are present.
+     *
+     * @param shape Shape to write the documentation of.
+     * @return Returns true if docs were written.
+     */
+    boolean writeShapeDocs(Shape shape) {
+        return shape.getTrait(DocumentationTrait.class)
+                .map(DocumentationTrait::getValue)
+                .map(docs -> {
+                    writeDocs(docs);
+                    return true;
+                }).orElse(false);
+    }
+
+    /**
+     * Writes member shape documentation comments if docs are present.
+     *
+     * @param model Model used to dereference targets.
+     * @param member Shape to write the documentation of.
+     * @return Returns true if docs were written.
+     */
+    boolean writeMemberDocs(Model model, MemberShape member) {
+        return member.getMemberTrait(model, DocumentationTrait.class)
+                .map(DocumentationTrait::getValue)
+                .map(docs -> {
+                    writeDocs(docs);
+                    return true;
+                }).orElse(false);
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/MediaTypeGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/MediaTypeGenerator.java
@@ -44,6 +44,7 @@ final class MediaTypeGenerator implements Runnable {
                 .orElseThrow(() -> new CodegenException(
                         "Media type symbols must have the property mediaTypeBaseSymbol: " + shape.getId()));
 
+        writer.writeShapeDocs(shape);
         writer.write("type $L $T", symbol.getName(), baseType)
                 .write("")
                 .openBlock("func (m $L) MediaType() string {", "}", symbol.getName(), () -> {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -53,6 +53,7 @@ final class StructureGenerator implements Runnable {
      */
     private void renderStructure() {
         Symbol symbol = symbolProvider.toSymbol(shape);
+        writer.writeShapeDocs(shape);
         writer.openBlock("type $L struct {", symbol.getName());
         writeMembers();
         writer.closeBlock("}").write("");
@@ -61,6 +62,7 @@ final class StructureGenerator implements Runnable {
     private void writeMembers() {
         for (MemberShape member : shape.getAllMembers().values()) {
             String memberName = symbolProvider.toMemberName(member);
+            writer.writeMemberDocs(model, member);
             writer.write("$L $P", memberName, symbolProvider.toSymbol(member));
         }
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -42,6 +42,7 @@ public class UnionGenerator implements Runnable {
     @Override
     public void run() {
         Symbol symbol = symbolProvider.toSymbol(shape);
+        writer.writeShapeDocs(shape);
 
         // Creates the parent interface for the union, which only defines a
         // non-exported method whose purpose is only to enable satisfying the
@@ -57,6 +58,7 @@ public class UnionGenerator implements Runnable {
             String unExportedMemberName = StringUtils.uncapitalize(exportedMemberName);
 
             // Create an interface for the member
+            writer.writeMemberDocs(model, member);
             writer.openBlock("type $L interface {", "}", exportedMemberName, () -> {
                 writer.write("$L", symbol.getName());
                 writer.write("is$L()", exportedMemberName);
@@ -81,6 +83,8 @@ public class UnionGenerator implements Runnable {
 
         // Creates a fallback type for use when an unknown member is found. This
         // could be the result of an outdated client, for example.
+        writer.writeDocs(symbol.getName()
+                + "Unknown is returned when a union member is returned over the wire, but has an unknown tag.");
         writer.openBlock("type $LUnknown struct {", "}", symbol.getName(), () -> {
             // The tag (member) name received over the wire. Necessary for re-serialization.
             writer.write("tag string");

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
@@ -110,7 +110,7 @@ public class DocumentationConverterTest {
                 Arguments.of("<h5>Foo</h5>bar", "Foo\n\nbar"),
                 Arguments.of("###### Foo\nbar", "Foo\n\nbar"),
                 Arguments.of("<h6>Foo</h6>bar", "Foo\n\nbar"),
-                Arguments.of("Inline ``code``", "Inline code"),
+                Arguments.of("Inline `code`", "Inline code"),
                 Arguments.of("```\ncode block\n```", "    code block"),
                 Arguments.of("```java\ncode block\n```", "    code block"),
                 Arguments.of("foo<br/>bar", "foo\n\nbar")

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
@@ -1,0 +1,119 @@
+package software.amazon.smithy.go.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class DocumentationConverterTest {
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void convertsDocs(String given, String expected) {
+        assertThat(DocumentationConverter.convert(given), equalTo(expected));
+    }
+
+    private static Stream<Arguments> cases() {
+        return Stream.of(
+                Arguments.of(
+                        "Testing 1 2 3",
+                        "Testing 1 2 3"
+                ),
+                Arguments.of(
+                        "<a href=\"https://example.com\">a link</a>",
+                        "a link (https://example.com)"
+                ),
+                Arguments.of(
+                        "<a href=\" https://example.com\">a link</a>",
+                        "a link (https://example.com)"
+                ),
+                Arguments.of(
+                        "<ul><li>Testing 1 2 3</li> <li>FooBar</li></ul>",
+                        "    * Testing 1 2 3\n\n    * FooBar"
+                ),
+                Arguments.of(
+                        "<ul> <li>Testing 1 2 3</li> <li>FooBar</li> </ul>",
+                        "    * Testing 1 2 3\n\n    * FooBar"
+                ),
+                Arguments.of(
+                        " <ul> <li>Testing 1 2 3</li> <li>FooBar</li> </ul>",
+                        "    * Testing 1 2 3\n\n    * FooBar"
+                ),
+                Arguments.of(
+                        "<ul> <li> <p>Testing 1 2 3</p> </li><li> <p>FooBar</p></li></ul>",
+                        "    * Testing 1 2 3\n\n    * FooBar"
+                ),
+                Arguments.of(
+                        "<ul> <li><code>Testing</code>: 1 2 3</li> <li>FooBar</li> </ul>",
+                        "    * Testing: 1 2 3\n\n    * FooBar"
+                ),
+                Arguments.of(
+                        "<ul> <li><p><code>FOO</code> Bar</p></li><li><p><code>Xyz</code> ABC</p></li></ul>",
+                        "    * FOO Bar\n\n    * Xyz ABC"
+                ),
+                Arguments.of(
+                        "<p><code>Testing</code>: 1 2 3</p>",
+                        "Testing: 1 2 3"
+                ),
+                Arguments.of(
+                        "<pre><code>Testing</code></pre>",
+                        "    Testing"
+                ),
+                Arguments.of(
+                        "<p>Testing 1 2                       3</p>",
+                        "Testing 1 2 3"
+                ),
+                Arguments.of(
+                        "<span data-target-type=\"operation\" data-service=\"secretsmanager\" "
+                                + "data-target=\"CreateSecret\">CreateSecret</span> <span data-target-type="
+                                + "\"structure\" data-service=\"secretsmanager\" data-target=\"SecretListEntry\">"
+                                + "SecretListEntry</span> <span data-target-type=\"structure\" data-service="
+                                + "\"secretsmanager\" data-target=\"CreateSecret$SecretName\">SecretName</span> "
+                                + "<span data-target-type=\"structure\" data-service=\"secretsmanager\" "
+                                + "data-target=\"SecretListEntry$KmsKeyId\">KmsKeyId</span>",
+                        "CreateSecret SecretListEntry SecretName KmsKeyId"
+                ),
+                Arguments.of(
+                        "<p> Deletes the replication configuration from the bucket. For information about replication"
+                                + " configuration, see "
+                                + "<a href=\" https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html\">"
+                                + "Cross-Region Replication (CRR)</a> in the <i>Amazon S3 Developer Guide</i>. </p>",
+                        "Deletes the replication configuration from the bucket. For information about replication "
+                                + "configuration, see Cross-Region Replication (CRR) "
+                                + "(https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) in the Amazon S3 "
+                                + "Developer Guide."
+                ),
+
+
+                Arguments.of(
+                        "* foo\n* bar",
+                        "    * foo\n\n    * bar"
+                ),
+                Arguments.of(
+                        "[a link](https://example.com)",
+                        "a link (https://example.com)"
+                ),
+                Arguments.of("", ""),
+                Arguments.of("<!-- foo bar -->", ""),
+                Arguments.of("# Foo\nbar", "Foo\n\nbar"),
+                Arguments.of("<h1>Foo</h1>bar", "Foo\n\nbar"),
+                Arguments.of("## Foo\nbar", "Foo\n\nbar"),
+                Arguments.of("<h2>Foo</h2>bar", "Foo\n\nbar"),
+                Arguments.of("### Foo\nbar", "Foo\n\nbar"),
+                Arguments.of("<h3>Foo</h3>bar", "Foo\n\nbar"),
+                Arguments.of("#### Foo\nbar", "Foo\n\nbar"),
+                Arguments.of("<h4>Foo</h4>bar", "Foo\n\nbar"),
+                Arguments.of("##### Foo\nbar", "Foo\n\nbar"),
+                Arguments.of("<h5>Foo</h5>bar", "Foo\n\nbar"),
+                Arguments.of("###### Foo\nbar", "Foo\n\nbar"),
+                Arguments.of("<h6>Foo</h6>bar", "Foo\n\nbar"),
+                Arguments.of("Inline ``code``", "Inline code"),
+                Arguments.of("```\ncode block\n```", "    code block"),
+                Arguments.of("```java\ncode block\n```", "    code block"),
+                Arguments.of("foo<br/>bar", "foo\n\nbar")
+        );
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This updates the code generator to output shape documentation, converting it from commonmark to godoc. This required some functionality from the 0.10 branch of Smithy. While that should release soonish, in the meantime you'll need to build and publish locally from that branch to build.

[Existing tests](https://github.com/aws/aws-sdk-go-v2/blob/master/private/model/api/docstring_test.go) from the go-based converter were ported over to make sure everything is still ship-shape. The only real difference is that it doesn't currently wrap lines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
