### PR TITLE
Add SetStream and RewindStream to HTTP Request Transport

### DIFF
--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -36,8 +36,8 @@ func (r *Request) Clone() *Request {
 	return &rc
 }
 
-// Rewind will rewind the io.Reader to the relative start position if it is an io.Seeker
-func (r *Request) Rewind() error {
+// RewindStream will rewind the io.Reader to the relative start position if it is an io.Seeker
+func (r *Request) RewindStream() error {
 	if !r.isStreamSeekable {
 		return fmt.Errorf("request stream is not seekable")
 	}

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,7 +12,9 @@ import (
 // middleware steps to use to serialize input, and send an operation's request.
 type Request struct {
 	*http.Request
-	Stream io.Reader
+	stream           io.Reader
+	isStreamSeekable bool
+	streamStartPos   int64
 }
 
 // NewStackRequest returns an initialized request ready to populated with the
@@ -25,31 +28,54 @@ func NewStackRequest() interface{} {
 	}
 }
 
-// WithContext returns a shallow copy of the Request for the new context.
-func (r *Request) WithContext(ctx context.Context) *Request {
-	return &Request{
-		Request: r.Request.WithContext(ctx),
-		Stream:  r.Stream,
-	}
-}
-
 // Clone returns a deep copy of the Request for the new context. A reference to
 // the Stream is copied, but the underlying stream is not copied.
-func (r *Request) Clone(ctx context.Context) *Request {
+func (r *Request) Clone() *Request {
+	rc := *r
+	rc.Request = rc.Request.Clone(context.TODO())
+	return &rc
+}
 
-	// TODO When should the underlying stream be rewound for next attempt?
-
-	return &Request{
-		Request: r.Request.Clone(ctx),
-		Stream:  r.Stream,
+// Rewind will rewind the io.Reader to the relative start position if it is an io.Seeker
+func (r *Request) Rewind() error {
+	if !r.isStreamSeekable {
+		return fmt.Errorf("request stream is not seekable")
 	}
+	_, err := r.stream.(io.Seeker).Seek(r.streamStartPos, io.SeekStart)
+	return err
+}
+
+// GetStream returns the request stream io.Reader
+func (r *Request) GetStream() io.Reader {
+	return r.stream
+}
+
+// SetStream returns a clone of the request with the stream set to the provided reader.
+// May return an error if the provided reader is seekable but returns an error.
+func (r *Request) SetStream(reader io.Reader) (rc *Request, err error) {
+	rc = r.Clone()
+
+	switch v := reader.(type) {
+	case io.Seeker:
+		rc.isStreamSeekable = true
+		n, err := v.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return rc, err
+		}
+		rc.streamStartPos = n
+	default:
+		rc.isStreamSeekable = false
+	}
+	rc.stream = reader
+
+	return rc, err
 }
 
 // Build returns a build standard HTTP request value from the Smithy request.
 // The request's stream is wrapped in a safe container that allows it to be
 // reused for subsiquent attempts.
-func (r *Request) Build() *http.Request {
-	req := r.Request.Clone(r.Request.Context())
+func (r *Request) Build(ctx context.Context) *http.Request {
+	req := r.Request.Clone(ctx)
 
 	// TODO wrap Stream in a container that provides safe reuse and rewinding
 	// of the underlying io.Reader. The standard http transport has race
@@ -66,7 +92,7 @@ func (r *Request) Build() *http.Request {
 	// likely want to defer this to the caller, and not allow the underlying
 	// http round tripper close the stream.
 
-	req.Body = ioutil.NopCloser(r.Stream)
+	req.Body = ioutil.NopCloser(r.stream)
 
 	return req
 }

--- a/transport/http/serialize_example_test.go
+++ b/transport/http/serialize_example_test.go
@@ -42,7 +42,7 @@ func ExampleRequest_serializeMiddleware() {
 	) {
 		// Returns the standard http Request for the handler to make request
 		// using standard http compatible client.
-		req := in.(*Request).Build()
+		req := in.(*Request).Build(context.Background())
 
 		fmt.Println("foo-name", req.Header.Get("foo-name"))
 		fmt.Println("bar-count", req.Header.Get("bar-count"))


### PR DESCRIPTION
Adds SetStream and Rewind functionality to the HTTP Request transport structure. Additionally modified the methods to only take a context when constructing the final request with `Build`