### PR TITLE
Add concept of source/module path versus import path

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -24,26 +24,31 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
  * An enum of all the built-in dependencies used by this package.
  */
 public enum GoDependency implements SymbolDependencyContainer {
-
     // The version in the stdlib dependencies should reflect the minimum Go version.
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
-    BIG("stdlib", "math/big", "1.14"),
-    TIME("stdlib", "time", "1.14"),
+    BIG("stdlib", "", "math/big", "1.14"),
+    TIME("stdlib", "", "time", "1.14"),
 
-    SMITHY("dependency", "github.com/awslabs/smithy-go", "v0.0.1");
+    SMITHY("dependency", "github.com/awslabs/smithy-go", "github.com/awslabs/smithy-go", "v0.0.1"),
+    SMITHY_HTTP_TRANSPORT("dependency", "github.com/awslabs/smithy-go",
+            "github.com/awslabs/smithy-go/transport/http", "v0.0.1"),
+    SMITHY_MIDDLEWARE("dependency", "github.com/awslabs/smithy-go",
+            "github.com/awslabs/smithy-go/middleware", "v0.0.1");
 
-    public final String packageName;
+    public final String sourcePath;
+    public final String importPath;
     public final String version;
     public final SymbolDependency dependency;
 
-    GoDependency(String type, String name, String version) {
+    GoDependency(String type, String sourcePath, String importPath, String version) {
         this.dependency = SymbolDependency.builder()
                 .dependencyType(type)
-                .packageName(name)
+                .packageName(sourcePath)
                 .version(version)
                 .build();
-        this.packageName = name;
+        this.sourcePath = sourcePath;
+        this.importPath = importPath;
         this.version = version;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -288,14 +288,14 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private SymbolReference createNamespaceReference(GoDependency dependency) {
-        String namespace = dependency.getDependencies().get(0).getPackageName();
+        String namespace = dependency.importPath;
         return createNamespaceReference(dependency, CodegenUtils.getDefaultPackageImportName(namespace));
     }
 
     private SymbolReference createNamespaceReference(GoDependency dependency, String alias) {
         // Go generally imports an entire package under a single name, which defaults to the last
         // part of the package name path. So we need to create a symbol for that namespace to reference.
-        String namespace = dependency.getDependencies().get(0).getPackageName();
+        String namespace = dependency.importPath;
         Symbol namespaceSymbol = Symbol.builder()
                 // We're not referencing a particular symbol from the namespace, so we leave the name blank.
                 .name("")


### PR DESCRIPTION
*Description of changes:* Separates the concept of a "source path" that is used for declaring a go.mod dependency versus an "import path" of a package within the given dependency.

Similar to how Java jars can contain multiple class namespaces, a Go module/repository can contain multiple packages at different import paths within.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
