### PR TITLE
Generate error interfaces and structures

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -29,6 +29,7 @@ public enum GoDependency implements SymbolDependencyContainer {
     // set the minimum go version.
     BIG("stdlib", "", "math/big", "1.14"),
     TIME("stdlib", "", "time", "1.14"),
+    FMT("stdlib", "", "fmt", "1.14"),
 
     SMITHY("dependency", "github.com/awslabs/smithy-go", "github.com/awslabs/smithy-go", "v0.0.1"),
     SMITHY_HTTP_TRANSPORT("dependency", "github.com/awslabs/smithy-go",

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -96,7 +96,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         // Reserved words that only apply to error members.
         ReservedWords reservedErrorMembers = new ReservedWordsBuilder()
                 .put("ErrorCode", "ErrorCode_")
-                .put("ErrorMessage", "ErrorMessage_")
                 .put("ErrorFault", "ErrorMessage_")
                 .put("Unwrap", "Unwrap_")
                 .put("Error", "Error_")
@@ -342,7 +341,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         Symbol.Builder builder = createPointableSymbolBuilder(shape, name, rootModuleName);
         if (shape.hasTrait(ErrorTrait.ID)) {
             builder.definitionFile("./api_errors.go")
-                    .addReference(createNamespaceReference(GoDependency.SMITHY, "smithy"));
+                    .addReference(createNamespaceReference(GoDependency.SMITHY, "smithy"))
+                    .addReference(createNamespaceReference(GoDependency.FMT));
         } else {
             builder.definitionFile("./api_types.go");
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -96,7 +96,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         // Reserved words that only apply to error members.
         ReservedWords reservedErrorMembers = new ReservedWordsBuilder()
                 .put("ErrorCode", "ErrorCode_")
-                .put("ErrorFault", "ErrorMessage_")
+                .put("ErrorFault", "ErrorFault_")
                 .put("Unwrap", "Unwrap_")
                 .put("Error", "Error_")
                 .build();


### PR DESCRIPTION
*Description of changes:*

This adds error generation. The errors are produced as interfaces in order to support inheritance.

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

import (
	"fmt"
	smithy "github.com/awslabs/smithy-go"
)

// Error encountered when no resource could be found.
type NoSuchResourceInterface interface {
	smithy.APIError
	isNoSuchResource()

	ErrorMessage() string
	ErrorFault() string
	ErrorCode() string

	// The type of resource that was not found.
	GetResourceType() string
	// HasResourceType returns whether ResourceType exists.
	HasResourceType() bool
}

// The concrete implementation for NoSuchResourceInterface. This should not be used directly.
type NoSuchResource struct {
	Message *string

	ResourceType *string
}

func (e *NoSuchResource) Error() string {
	return fmt.Sprintf("%s: %s", e.ErrorCode(), e.ErrorMessage())
}
func (e *NoSuchResource) isNoSuchResource() {}
func (e *NoSuchResource) ErrorMessage() string {
	if e.Message == nil {
		return ""
	}
	return *e.Message
}
func (e *NoSuchResource) ErrorCode() string             { return "NoSuchResource" }
func (e *NoSuchResource) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
func (e *NoSuchResource) GetMessage() string {
	return *e.Message
}
func (e *NoSuchResource) HasMessage() bool {
	return e.Message != nil
}
func (e *NoSuchResource) GetResourceType() string {
	return *e.ResourceType
}
func (e *NoSuchResource) HasResourceType() bool {
	return e.ResourceType != nil
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
