### PR TITLE
Move types into their own namespace

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -120,4 +120,11 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         writers.useShapeWriter(shape, writer -> new UnionGenerator(model, symbolProvider, writer, shape).run());
         return null;
     }
+
+    @Override
+    public Void serviceShape(ServiceShape shape) {
+        // TODO: implement client generation
+        writers.useShapeWriter(shape, writer -> { });
+        return null;
+    }
 }


### PR DESCRIPTION
This moves generated types for most shapes into a "types" namespace.
This allows for things like synthesized types for operation input /
output without risk of conflicting names.

As part of this a symbol is generated for the service shape (client)
to enable generating an empty file for the client. This is needed as
otherwise `go fmt` will complain about an empty package.

The generated module will now look like:

```
├── api_client.go
├── go.mod
└── types
    ├── enums.go
    ├── errors.go
    └── types.go
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
