### PR TITLE
Fix middleware generator bug

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -120,8 +120,8 @@ public final class GoStackStepMiddlewareGenerator {
             GoWriter writer,
             BiConsumer<GoStackStepMiddlewareGenerator, GoWriter> handlerBodyConsumer
     ) {
-        writeMiddleware(writer, (m, w) -> {
-        }, handlerBodyConsumer);
+        writeMiddleware(writer, handlerBodyConsumer, (m, w) -> {
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes a bug in the middleware generator that resulted in the handler contents being written into the structure field definition.