### PR TITLE
Generate clients

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -21,19 +21,24 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -61,6 +66,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private final List<GoIntegration> integrations = new ArrayList<>();
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
+    private final List<RuntimeClientPlugin> runtimePlugins = new ArrayList<>();
 
     CodegenVisitor(PluginContext context) {
         // Load all integrations.
@@ -70,6 +76,10 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 .forEach(integration -> {
                     LOGGER.info(() -> "Adding GoIntegration: " + integration.getClass().getName());
                     integrations.add(integration);
+                    integration.getClientPlugins().forEach(runtimePlugin -> {
+                        LOGGER.info(() -> "Adding Go runtime plugin: " + runtimePlugin);
+                        runtimePlugins.add(runtimePlugin);
+                    });
                 });
         integrations.sort(Comparator.comparingInt(GoIntegration::getOrder));
 
@@ -184,7 +194,12 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     @Override
     public Void structureShape(StructureShape shape) {
-        writers.useShapeWriter(shape, writer -> new StructureGenerator(model, symbolProvider, writer, shape).run());
+        if (shape.hasTrait(SyntheticClone.ID)) {
+            return null;
+        }
+        Symbol symbol = symbolProvider.toSymbol(shape);
+        writers.useShapeWriter(shape, writer -> new StructureGenerator(
+                model, symbolProvider, writer, shape, symbol).run());
         return null;
     }
 
@@ -204,8 +219,25 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     @Override
     public Void serviceShape(ServiceShape shape) {
-        // TODO: implement client generation
-        writers.useShapeWriter(shape, writer -> {
+        if (!Objects.equals(service, shape)) {
+            LOGGER.fine(() -> "Skipping `" + shape.getId() + "` because it is not `" + service.getId() + "`");
+            return null;
+        }
+
+        writers.useShapeWriter(shape, serviceWriter -> {
+            new ServiceGenerator(settings, model, symbolProvider, serviceWriter, shape, integrations,
+                    runtimePlugins).run();
+
+            // Generate each operation for the service. We do this here instead of via the operation visitor method to
+            // limit it to the operations bound to the service.
+            TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+            Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
+            for (OperationShape operation : containedOperations) {
+                Symbol operationSymbol = symbolProvider.toSymbol(operation);
+                writers.useShapeWriter(operation, operationWriter -> new OperationGenerator(
+                        settings, model, symbolProvider, operationWriter, service, operation,
+                        operationSymbol).run());
+            }
         });
         return null;
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -226,7 +226,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         writers.useShapeWriter(shape, serviceWriter -> {
             new ServiceGenerator(settings, model, symbolProvider, serviceWriter, shape, integrations,
-                    runtimePlugins).run();
+                    runtimePlugins, applicationProtocol).run();
 
             // Generate each operation for the service. We do this here instead of via the operation visitor method to
             // limit it to the operations bound to the service.
@@ -236,7 +236,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 Symbol operationSymbol = symbolProvider.toSymbol(operation);
                 writers.useShapeWriter(operation, operationWriter -> new OperationGenerator(
                         settings, model, symbolProvider, operationWriter, service, operation,
-                        operationSymbol).run());
+                        operationSymbol, applicationProtocol).run());
             }
         });
         return null;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+/**
+ * Generates a client operation and associated custom shapes.
+ */
+final class OperationGenerator implements Runnable {
+
+    private final GoSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+    private final GoWriter writer;
+    private final ServiceShape service;
+    private final OperationShape operation;
+    private final Symbol operationSymbol;
+
+    OperationGenerator(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoWriter writer,
+            ServiceShape service,
+            OperationShape operation,
+            Symbol operationSymbol
+    ) {
+        this.settings = settings;
+        this.model = model;
+        this.symbolProvider = symbolProvider;
+        this.writer = writer;
+        this.service = service;
+        this.operation = operation;
+        this.operationSymbol = operationSymbol;
+    }
+
+    @Override
+    public void run() {
+        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+
+        if (!operationIndex.getInput(operation).isPresent()) {
+            // Theoretically this shouldn't ever get hit since we automatically insert synthetic inputs / outputs.
+            throw new CodegenException(
+                    "Operations are required to have input shapes in order to allow for future evolution.");
+        }
+        StructureShape inputShape = operationIndex.getInput(operation).get();
+        Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
+
+        if (!operationIndex.getOutput(operation).isPresent()) {
+            throw new CodegenException(
+                    "Operations are required to have output shapes in order to allow for future evolution.");
+        }
+        StructureShape outputShape = operationIndex.getOutput(operation).get();
+        Symbol outputSymbol = symbolProvider.toSymbol(outputShape);
+
+        writer.writeShapeDocs(operation);
+        Symbol contextSymbol = SymbolUtils.createValueSymbolBuilder("Context", GoDependency.CONTEXT).build();
+        writer.openBlock("func (c $P) $T(ctx $T, params $P, opts ...func(*Options)) ($P, error) {", "}",
+                serviceSymbol, operationSymbol, contextSymbol, inputSymbol, outputSymbol, () -> {
+                    // TODO: create middleware stack
+                    writer.write("options := c.options.Copy()");
+                    writer.openBlock("for _, fn := range optFns {", "}", () -> {
+                        writer.write("fn(&options)");
+                    });
+                    writer.openBlock("for _, fn := range options.APIOptions {", "}", () -> {
+                        writer.write("if err := fn(stack); err != nil { return nil, err }");
+                    });
+                    // TODO: resolve middleware stack
+                    writer.write("return nil, nil");
+                }).write("");
+
+        // Write out the input and output structures. These are written out here to prevent naming conflicts with other
+        // shapes in the model.
+        new StructureGenerator(model, symbolProvider, writer, inputShape, inputSymbol).run();
+
+        // The output structure gets a metadata member added.
+        Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder(
+                "Metadata", GoDependency.SMITHY_MIDDLEWARE).build();
+        new StructureGenerator(model, symbolProvider, writer, outputShape, outputSymbol).renderStructure(() -> {
+            writer.write("");
+            writer.writeDocs("Metadata pertaining to the operation's result.");
+            writer.write("ResultMetadata $T", metadataSymbol);
+        });
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.List;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.integration.GoIntegration;
+import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.StringTrait;
+import software.amazon.smithy.model.traits.TitleTrait;
+
+/**
+ * Generates a service client and configuration.
+ */
+final class ServiceGenerator implements Runnable {
+
+    public static final String CONFIG_NAME = "Options";
+    public static final String API_OPTIONS_FUNC_NAME = "APIOptionFunc";
+
+    private final GoSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+    private final GoWriter writer;
+    private final ServiceShape service;
+    private final List<GoIntegration> integrations;
+    private final List<RuntimeClientPlugin> runtimePlugins;
+
+    ServiceGenerator(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoWriter writer,
+            ServiceShape service,
+            List<GoIntegration> integrations,
+            List<RuntimeClientPlugin> runtimePlugins
+    ) {
+        this.settings = settings;
+        this.model = model;
+        this.symbolProvider = symbolProvider;
+        this.writer = writer;
+        this.service = service;
+        this.integrations = integrations;
+        this.runtimePlugins = runtimePlugins;
+    }
+
+    @Override
+    public void run() {
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+        writer.writeShapeDocs(service);
+        writer.openBlock("type $T struct {", "}", serviceSymbol, () -> {
+            writer.write("options $L", CONFIG_NAME);
+        });
+
+        generateConstructor(serviceSymbol);
+
+        String clientId = CodegenUtils.getDefaultPackageImportName(settings.getModuleName());
+        String clientTitle = service.getTrait(TitleTrait.class).map(StringTrait::getValue).orElse(clientId);
+
+        writer.writeDocs("ServiceID returns the name of the identifier for the service API.");
+        writer.write("func (c $P) ServiceID() string { return $S }", serviceSymbol, clientId);
+
+        writer.writeDocs("ServiceName returns the full service title.");
+        writer.write("func (c $P) ServiceName() string { return $S }", serviceSymbol, clientTitle);
+
+        generateConfig();
+
+        Symbol stackSymbol = SymbolUtils.createPointableSymbolBuilder("Stack", GoDependency.SMITHY_MIDDLEWARE).build();
+        writer.write("type $L func($P) error", API_OPTIONS_FUNC_NAME, stackSymbol);
+    }
+
+    private void generateConstructor(Symbol serviceSymbol) {
+        writer.writeDocs(String.format("New returns an initialized %s based on the functional options. "
+                    + "Provide additional functional options to further configure the behavior "
+                    + "of the client, such as changing the client's endpoint or adding custom "
+                    + "middleware behavior.", serviceSymbol.getName()));
+        writer.openBlock("func New(options $L) ($P, error) {", "}",
+                CONFIG_NAME, serviceSymbol, () -> {
+
+            writer.write("options = options.Copy()").write("");
+
+            // Run any config initialization functions registered by runtime plugins.
+            for (RuntimeClientPlugin runtimeClientPlugin : runtimePlugins) {
+                if (!runtimeClientPlugin.matchesService(model, service)
+                        || !runtimeClientPlugin.getResolveFunction().isPresent()) {
+                    continue;
+                }
+                writer.write("if err := $T(&options); err != nil { return nil, err }",
+                        runtimeClientPlugin.getResolveFunction().get());
+                writer.write("");
+            }
+
+            writer.openBlock("client := &$T {", "}", serviceSymbol, () -> {
+                writer.write("options: options,");
+            }).write("");
+
+            writer.write("return client, nil");
+        });
+    }
+
+    private void generateConfig() {
+        writer.openBlock("type $L struct {", "}", CONFIG_NAME, () -> {
+            writer.writeDocs("Set of options to modify how an operation is invoked. These apply to all operations "
+                    + "invoked for this client. Use functional options on operation call to modify this "
+                    + "list for per operation behavior."
+            );
+            writer.write("APIOptions []$L", API_OPTIONS_FUNC_NAME).write("");
+
+            for (GoIntegration integration : integrations) {
+                integration.addConfigFields(settings, model, symbolProvider, writer);
+            }
+
+            // TODO: add application protocol defaults
+        }).write("");
+
+        writer.writeDocs("Copy creates a clone where the APIOptions list is deep copied.");
+        writer.openBlock("func (o $L) Copy() $L {", "}", CONFIG_NAME, CONFIG_NAME, () -> {
+            writer.write("to := o");
+            writer.write("to.APIOptions = make([]$L, len(o.APIOptions))", API_OPTIONS_FUNC_NAME);
+            writer.write("copy(to.APIOptions, o.APIOptions)");
+            writer.write("return to");
+        });
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -19,7 +19,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
@@ -145,6 +148,60 @@ public interface GoIntegration {
      * @param writer TypeScript writer to write to.
      */
     default void addConfigInterfaceFields(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoWriter writer
+    ) {
+        // pass
+    }
+
+    /**
+     * Gets a list of plugins to apply to the generated client.
+     *
+     * @return Returns the list of RuntimePlugins to apply to the client.
+     */
+    default List<RuntimeClientPlugin> getClientPlugins() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Adds additional client config fields.
+     *
+     * <p>Implementations of this method are expected to add fields to the
+     * "ClientOptions" struct of a generated client. Implementations are
+     * expected to write field names and their type signatures. Any number
+     * of fields can be added, and any {@link Symbol} or {@link SymbolReference}
+     * objects that are written to the writer are automatically imported, and
+     * any of their contained {@link SymbolDependency} values are automatically
+     * added to the generated {@code go.mod} file.
+     *
+     * <p>For example, the following code adds two fields to a client:
+     *
+     * <pre>
+     * {@code
+     * public final class MyIntegration implements GoIntegration {
+     *     public void addConfigFields(
+     *             GoSettings settings,
+     *             Model model,
+     *             SymbolProvider symbolProvider,
+     *             GoWriter writer
+     *     ) {
+     *         writer.writeDocs("The docs for foo...");
+     *         writer.write("Foo *string");
+     *
+     *         writer.writeDocs("The docs for bar...");
+     *         writer.write("Bar string;");
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param settings Settings used to generate.
+     * @param model Model to generate from.
+     * @param symbolProvider Symbol provider used for codegen.
+     * @param writer Go writer to write to.
+     */
+    default void addConfigFields(
             GoSettings settings,
             Model model,
             SymbolProvider symbolProvider,

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Represents a runtime plugin for a client that hooks into various aspects
+ * of Go code generation, including adding configuration settings
+ * to clients and middleware plugins to both clients and commands.
+ *
+ * <p>These runtime client plugins are registered through the
+ * {@link GoIntegration} SPI and applied to the code generator at
+ * build-time.
+ */
+public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientPlugin> {
+
+    private final Symbol resolveFunction;
+    private final BiPredicate<Model, ServiceShape> servicePredicate;
+    private final OperationPredicate operationPredicate;
+
+    private RuntimeClientPlugin(Builder builder) {
+        resolveFunction = builder.resolveFunction;
+        operationPredicate = builder.operationPredicate;
+        servicePredicate = builder.servicePredicate;
+    }
+
+    @FunctionalInterface
+    public interface OperationPredicate {
+        /**
+         * Tests if middleware is applied to an individual operation.
+         *
+         * @param model Model the operation belongs to.
+         * @param service Service the operation belongs to.
+         * @param operation Operation to test.
+         * @return Returns true if middleware should be applied to the operation.
+         */
+        boolean test(Model model, ServiceShape service, OperationShape operation);
+    }
+
+    /**
+     * Gets the optionally present symbol that points to a function that operates
+     * on the client options at creation time.
+     *
+     * <p>Any configuration that a plugin requires in order to function should be
+     * checked in this function, either setting a default value if possible or
+     * returning an error if not.
+     *
+     * <p>This function must take a client options struct as input and return a
+     * client options struct and an error as output.
+     *
+     * @return Returns the optionally present resolve function.
+     */
+    public Optional<Symbol> getResolveFunction() {
+        return Optional.ofNullable(resolveFunction);
+    }
+
+    /**
+     * Returns true if this plugin applies to the given service.
+     *
+     * <p>By default, a plugin applies to all services but not to specific
+     * commands. You an configure a plugin to apply only to a subset of
+     * services (for example, only apply to a known service or a service
+     * with specific traits) or to no services at all (for example, if
+     * the plugin is meant to by command-specific and not on every
+     * command executed by the service).
+     *
+     * @param model The model the service belongs to.
+     * @param service Service shape to test against.
+     * @return Returns true if the plugin is applied to the given service.
+     * @see #matchesOperation(Model, ServiceShape, OperationShape)
+     */
+    public boolean matchesService(Model model, ServiceShape service) {
+        return servicePredicate.test(model, service);
+    }
+
+    /**
+     * Returns true if this plugin applies to the given operation.
+     *
+     * @param model Model the operation belongs to.
+     * @param service Service the operation belongs to.
+     * @param operation Operation to test against.
+     * @return Returns true if the plugin is applied to the given operation.
+     * @see #matchesService(Model, ServiceShape)
+     */
+    public boolean matchesOperation(Model model, ServiceShape service, OperationShape operation) {
+        return operationPredicate.test(model, service, operation);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public SmithyBuilder<RuntimeClientPlugin> toBuilder() {
+        return builder()
+                .resolveFunction(resolveFunction)
+                .servicePredicate(servicePredicate)
+                .operationPredicate(operationPredicate);
+    }
+
+    /**
+     * Builds a {@code RuntimeClientPlugin}.
+     */
+    public static final class Builder implements SmithyBuilder<RuntimeClientPlugin> {
+        private Symbol resolveFunction;
+        private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
+        private OperationPredicate operationPredicate = (model, service, operation) -> false;
+
+        @Override
+        public RuntimeClientPlugin build() {
+            return new RuntimeClientPlugin(this);
+        }
+
+        /**
+         * Sets the symbol used to configure client options.
+         *
+         * @param resolveFunction Resolved configuration symbol to set.
+         * @return Returns the builder.
+         */
+        public Builder resolveFunction(Symbol resolveFunction) {
+            this.resolveFunction = resolveFunction;
+            return this;
+        }
+
+        /**
+         * Sets a predicate that determines if the plugin applies to a
+         * specific operation.
+         *
+         * <p>When this method is called, the {@code servicePredicate} is
+         * automatically configured to return false for every service.
+         *
+         * <p>By default, a plugin applies globally to a service, which thereby
+         * applies to every operation when the middleware stack is copied.
+         *
+         * @param operationPredicate Operation matching predicate.
+         * @return Returns the builder.
+         * @see #servicePredicate(BiPredicate)
+         */
+        public Builder operationPredicate(OperationPredicate operationPredicate) {
+            this.operationPredicate = Objects.requireNonNull(operationPredicate);
+            servicePredicate = (model, service) -> false;
+            return this;
+        }
+
+        /**
+         * Configures a predicate that makes a plugin only apply to a set of
+         * operations that match one or more of the set of given shape names,
+         * and ensures that the plugin is not applied globally to services.
+         *
+         * <p>By default, a plugin applies globally to a service, which thereby
+         * applies to every operation when the middleware stack is copied.
+         *
+         * @param operationNames Set of operation names.
+         * @return Returns the builder.
+         */
+        public Builder appliesOnlyToOperations(Set<String> operationNames) {
+            operationPredicate((model, service, operation) -> operationNames.contains(operation.getId().getName()));
+            return servicePredicate((model, service) -> false);
+        }
+
+        /**
+         * Configures a predicate that applies the plugin to a service if the
+         * predicate matches a given model and service.
+         *
+         * <p>When this method is called, the {@code operationPredicate} is
+         * automatically configured to return false for every operation,
+         * causing the plugin to only apply to services and not to individual
+         * operations.
+         *
+         * <p>By default, a plugin applies globally to a service, which
+         * thereby applies to every operation when the middleware stack is
+         * copied. Setting a custom service predicate is useful for plugins
+         * that should only be applied to specific services or only applied
+         * at the operation level.
+         *
+         * @param servicePredicate Service predicate.
+         * @return Returns the builder.
+         */
+        public Builder servicePredicate(BiPredicate<Model, ServiceShape> servicePredicate) {
+            this.servicePredicate = Objects.requireNonNull(servicePredicate);
+            operationPredicate = (model, service, operation) -> false;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This is a draft of client generation, based on https://github.com/aws/aws-sdk-go-v2/pull/530

Outside of that the only real gap is the lack application protocol handling, which will be necessary to set some config defaults and to initialize the middleware stack.

A generated service currently looks like:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

import (
	"github.com/awslabs/smithy-go/middleware"
	smithyhttp "github.com/awslabs/smithy-go/transport/http"
)

// Provides weather forecasts.
type Client struct {
	options Options
}

// New returns an initialized Client based on the functional options.
// Provide additional functional options to further configure the behavior
// of the client, such as changing the client's endpoint or adding custom
// middleware behavior.
func New(options Options) (*Client, error) {
	options = options.Copy()

	client := &Client{
		options: options,
	}

	return client, nil
}

// ServiceID returns the name of the identifier for the service API.
func (c *Client) ServiceID() string { return "weather" }

// ServiceName returns the full service title.
func (c *Client) ServiceName() string { return "weather" }

type Options struct {
	// Set of options to modify how an operation is invoked. These apply to all operations invoked for this client. Use functional options on operation call to modify this list for per operation behavior.
	APIOptions []APIOptionFunc

	// The HTTP client to invoke API calls with. Defaults to client's default HTTP implementation if nil.
	HTTPClient HTTPClient
}

type HTTPClient interface {
	Do(*smithyhttp.Request) (*smithyhttp.Response, error)
}

// Copy creates a clone where the APIOptions list is deep copied.
func (o Options) Copy() Options {
	to := o
	to.APIOptions = make([]APIOptionFunc, len(o.APIOptions))
	copy(to.APIOptions, o.APIOptions)
	return to
}

type APIOptionFunc func(*middleware.Stack) error
```

A generated operation current looks like:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package weather

import (
	"context"
	smithy "github.com/awslabs/smithy-go"
	"github.com/awslabs/smithy-go/middleware"
	smithyhttp "github.com/awslabs/smithy-go/transport/http"
	"weather/types"
)

func (c *Client) GetCity(ctx context.Context, params *GetCityInput, opts ...func(*Options)) (*GetCityOutput, error) {
	stack := middleware.NewStack("GetCity", smithyhttp.NewStackRequest)
	options := c.options.Copy()
	for _, fn := range optFns {
		fn(&options)
	}
	for _, fn := range options.APIOptions {
		if err := fn(stack); err != nil {
			return nil, err
		}
	}
	handler := middleware.DecorateHandler(smithyhttp.ClientHandler{Client: options.HTTPClient}, stack)
	result, metadata, err := handler.Handle(ctx, params)
	if err != nil {
		return nil, err
	}
	out := result.(*GetCityOutput)
	out.ResultMetadata = metadata
	return out, nil
}

// The input used to get a city.
type GetCityInput struct {
	CityId *string
}

type GetCityOutput struct {
	City        *types.CitySummary
	Coordinates *types.CityCoordinates
	Metadata    smithy.Document
	Name        *string

	// Metadata pertaining to the operation's result.
	ResultMetadata middleware.Metadata
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
