### PR TITLE
HttpBinding Deserialization Support

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -129,5 +130,41 @@ public final class CodegenUtils {
      */
     public static String getSyntheticTypeNamespace() {
         return CodegenUtils.SYNTHETIC_NAMESPACE;
+    }
+
+    /**
+     * Get the pointer reference to operand , if symbol is pointable.
+     * This method can be used by deserializers to get pointer to
+     * operand.
+     *
+     * @param symbol The Symbol corresponding to shape whose value needs to be assigned.
+     * @param operand The Operand is the value to be assigned to the symbol shape.
+     * @return The Operand, along with pointer reference if applicable
+     */
+    public static String generatePointerReferenceIfPointable(Symbol symbol, String operand) {
+        if (symbol.getProperty(SymbolUtils.POINTABLE, Boolean.class)
+                .orElse(false)) {
+            return '&' + operand;
+        }
+        return operand;
+    }
+
+    /**
+     * Get SDK equivalent timestamp format name for TimestampFormatTrait.Format enum.
+     *
+     * @param format The format is TimestampFormatTrait.Format enum
+     * @return SDK equivalent timestamp format name
+     */
+    public static String getTimeStampFormatName(TimestampFormatTrait.Format format) {
+        switch (format) {
+            case DATE_TIME:
+                return "ISO8601TimeFormatName";
+            case EPOCH_SECONDS:
+                return "UnixTimeFormatName";
+            case HTTP_DATE:
+                return "RFC822TimeFormat";
+            default:
+                throw new CodegenException("unknown timestamp format found: " + format.toString());
+        }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -147,16 +147,22 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         if (protocolGenerator != null) {
             LOGGER.info("Generating serde for protocol " + protocolGenerator.getProtocol() + " on " + service.getId());
+            ProtocolGenerator.GenerationContext context = new ProtocolGenerator.GenerationContext();
+            context.setProtocolName(protocolGenerator.getProtocolName());
+            context.setIntegrations(integrations);
+            context.setModel(model);
+            context.setService(service);
+            context.setSettings(settings);
+            context.setSymbolProvider(symbolProvider);
+
             writers.useFileWriter("serializers.go", settings.getModuleName(), writer -> {
-                ProtocolGenerator.GenerationContext context = new ProtocolGenerator.GenerationContext();
-                context.setProtocolName(protocolGenerator.getProtocolName());
-                context.setIntegrations(integrations);
-                context.setModel(model);
-                context.setService(service);
-                context.setSettings(settings);
-                context.setSymbolProvider(symbolProvider);
                 context.setWriter(writer);
                 protocolGenerator.generateRequestSerializers(context);
+            });
+
+            writers.useFileWriter("deserializers.go", settings.getModuleName(), writer -> {
+                context.setWriter(writer);
+                protocolGenerator.generateResponseDeserializers(context);
             });
         }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -31,6 +31,8 @@ public enum GoDependency implements SymbolDependencyContainer {
     TIME("stdlib", "", "time", null, "1.14"),
     FMT("stdlib", "", "fmt", null, "1.14"),
     CONTEXT("stdlib", "", "context", null, "1.14"),
+    STRCONV("stdlib", "", "strconv", null, "1.14"),
+    BASE64ENCODING("stdlib", "", "encoding/base64", null, "1.14"),
 
     SMITHY("dependency", "github.com/awslabs/smithy-go", "github.com/awslabs/smithy-go",
             "smithy", "v0.0.1"),
@@ -40,7 +42,9 @@ public enum GoDependency implements SymbolDependencyContainer {
             "github.com/awslabs/smithy-go/middleware", null, "v0.0.1"),
 
     AWS_REST_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
-            "github.com/aws/aws-sdk-go-v2/aws/protocol/rest", null, "v0.22.0");
+            "github.com/aws/aws-sdk-go-v2/aws/protocol/rest", null, "v0.22.0"),
+    AWS_PRIVATE_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
+            "github.com/aws/aws-sdk-go-v2/aws/private/protocol", null, "v0.22.0");
 
     public final String sourcePath;
     public final String importPath;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -32,7 +32,7 @@ public enum GoDependency implements SymbolDependencyContainer {
     FMT("stdlib", "", "fmt", null, "1.14"),
     CONTEXT("stdlib", "", "context", null, "1.14"),
     STRCONV("stdlib", "", "strconv", null, "1.14"),
-    BASE64ENCODING("stdlib", "", "encoding/base64", null, "1.14"),
+    BASE64("stdlib", "", "encoding/base64", null, "1.14"),
 
     SMITHY("dependency", "github.com/awslabs/smithy-go", "github.com/awslabs/smithy-go",
             "smithy", "v0.0.1"),

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -462,7 +462,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 return operand;
             case BOOLEAN:
                 writer.addUseImports(GoDependency.STRCONV);
-                return String.format("strConv.ParseBool(%s)", operand);
+                return String.format("strconv.ParseBool(%s)", operand);
             case TIMESTAMP:
                 writer.addUseImports(GoDependency.AWS_PRIVATE_PROTOCOL);
                 HttpBindingIndex bindingIndex = model.getKnowledge(HttpBindingIndex.class);
@@ -477,7 +477,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 return "t";
             case INTEGER:
                 writer.addUseImports(GoDependency.STRCONV);
-                return String.format("strConv.ParseInt(%s,0,0)", operand);
+                return String.format("strconv.ParseInt(%s,0,0)", operand);
             case BLOB:
                 writer.addUseImports(GoDependency.BASE64);
                 writer.write("b, err := base64.StdEncoding.DecodeString($L)", operand);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -417,7 +417,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol smithyHttpResponsePointableSymbol = SymbolUtils.createPointableSymbolBuilder(
                 "Response", GoDependency.SMITHY_HTTP_TRANSPORT).build();
 
-        writer.addUseImports(smithyHttpResponsePointableSymbol);
         writer.addUseImports(GoDependency.FMT);
 
         String functionName = ProtocolGenerator.getOperationDeserFunctionName(targetSymbol, getProtocolName());
@@ -511,12 +510,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         MemberShape memberShape = binding.getMember();
         Shape targetShape = model.expectShape(memberShape.getTarget());
-        Symbol targetSymbol = symbolProvider.toSymbol(targetShape);
         String memberName = symbolProvider.toMemberName(memberShape);
 
         switch (binding.getLocation()) {
             case HEADER:
-                writeHeaderDeserializerFunction(writer, model, memberName, targetSymbol, targetShape, binding);
+                writeHeaderDeserializerFunction(writer, model, memberName, targetShape, binding);
                 break;
             case PREFIX_HEADERS:
                 if (!targetShape.isMapShape()) {
@@ -545,13 +543,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
 
-    private void writeHeaderDeserializerFunction(GoWriter writer, Model model, String memberName, Symbol targetSymbol,
-            Shape targetShape, HttpBinding binding) {
+    private void writeHeaderDeserializerFunction(GoWriter writer, Model model, String memberName,
+                                                 Shape targetShape, HttpBinding binding) {
         writer.openBlock("if val := response.Header.Get($S); val != $S {", "}",
                 binding.getLocationName(), "", () -> {
                     String value = generateHttpBindingsValue(writer, model, targetShape, binding, "val");
                     writer.write("v.$L = $L", memberName,
-                            CodegenUtils.generatePointerReferenceIfPointable(targetSymbol, value));
+                            CodegenUtils.generatePointerReferenceIfPointable(targetShape, value));
                 });
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -153,6 +153,19 @@ public interface ProtocolGenerator {
     }
 
     /**
+     * Generates the name of a deserializer function for shapes of a service.
+     *
+     * @param symbol   The symbol the deserializer function is being generated for.
+     * @param protocol Name of the protocol being generated.
+     * @return Returns the generated function name.
+     */
+    static String getOperationDeserFunctionName(Symbol symbol, String protocol) {
+        return protocol
+                + "_deserializeHttpBindings"
+                + symbol.getName();
+    }
+
+    /**
      * Generates the name of a serializer function for shapes of a service.
      *
      * @param symbol        The symbol the serializer function is being generated for.


### PR DESCRIPTION
* Adds support for deserializer generation for "rest" bindings of operation shapes. 

Generated deserializers.go for lex-runtime:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package lexruntimeservice

import (
	"fmt"
	"github.com/aws/aws-sdk-go-v2/service/lexruntimeservice/types"
	smithyhttp "github.com/awslabs/smithy-go/transport/http"
)

func awsRestjson1_deserializeHttpBindingsPutSessionOutput(v *types.PutSessionOutput, response *smithyhttp.Response) error {
	if v == nil {
		return fmt.Errorf("unsupported deserialization for nil %T", v)
	}

	if val := response.Header.Get("Content-Type"); val != "" {
		v.ContentType = &val
	}

	if val := response.Header.Get("x-amz-lex-dialog-state"); val != "" {
		v.DialogState = types.DialogState(val)
	}

	if val := response.Header.Get("x-amz-lex-intent-name"); val != "" {
		v.IntentName = &val
	}

	if val := response.Header.Get("x-amz-lex-message"); val != "" {
		v.Message = &val
	}

	if val := response.Header.Get("x-amz-lex-message-format"); val != "" {
		v.MessageFormat = types.MessageFormatType(val)
	}

	if val := response.Header.Get("x-amz-lex-session-attributes"); val != "" {
		v.SessionAttributes = &val
	}

	if val := response.Header.Get("x-amz-lex-session-id"); val != "" {
		v.SessionId = &val
	}

	if val := response.Header.Get("x-amz-lex-slot-to-elicit"); val != "" {
		v.SlotToElicit = &val
	}

	if val := response.Header.Get("x-amz-lex-slots"); val != "" {
		v.Slots = &val
	}

	return nil
}
func awsRestjson1_deserializeHttpBindingsPostContentOutput(v *types.PostContentOutput, response *smithyhttp.Response) error {
	if v == nil {
		return fmt.Errorf("unsupported deserialization for nil %T", v)
	}

	if val := response.Header.Get("Content-Type"); val != "" {
		v.ContentType = &val
	}

	if val := response.Header.Get("x-amz-lex-dialog-state"); val != "" {
		v.DialogState = types.DialogState(val)
	}

	if val := response.Header.Get("x-amz-lex-input-transcript"); val != "" {
		v.InputTranscript = &val
	}

	if val := response.Header.Get("x-amz-lex-intent-name"); val != "" {
		v.IntentName = &val
	}

	if val := response.Header.Get("x-amz-lex-message"); val != "" {
		v.Message = &val
	}

	if val := response.Header.Get("x-amz-lex-message-format"); val != "" {
		v.MessageFormat = types.MessageFormatType(val)
	}

	if val := response.Header.Get("x-amz-lex-sentiment"); val != "" {
		v.SentimentResponse = &val
	}

	if val := response.Header.Get("x-amz-lex-session-attributes"); val != "" {
		v.SessionAttributes = &val
	}

	if val := response.Header.Get("x-amz-lex-session-id"); val != "" {
		v.SessionId = &val
	}

	if val := response.Header.Get("x-amz-lex-slot-to-elicit"); val != "" {
		v.SlotToElicit = &val
	}

	if val := response.Header.Get("x-amz-lex-slots"); val != "" {
		v.Slots = &val
	}

	return nil
}

func awsRestjson1_deserializeHttpBindingsLimitExceededException(v *types.LimitExceededException, response *smithyhttp.Response) error {
	if v == nil {
		return fmt.Errorf("unsupported deserialization for nil %T", v)
	}

	if val := response.Header.Get("Retry-After"); val != "" {
		v.RetryAfterSeconds = &val
	}

	return nil
}


```