### PR TITLE
Update namespace handling

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -95,6 +96,20 @@ public final class CodegenUtils {
             return packageName;
         }
         return packageName.substring(packageName.lastIndexOf('/') + 1);
+    }
+
+    /**
+     * Gets the alias to use when referencing the given symbol outside of its namespace.
+     *
+     * <p>The default value is the last path component of the symbol's namespace.
+     *
+     * @param symbol The symbol whose whose namespace alias should be retrieved.
+     * @return The alias of the symbol's namespace.
+     */
+    public static String getSymbolNamespaceAlias(Symbol symbol) {
+        return symbol.getProperty(SymbolUtils.NAMESPACE_ALIAS, String.class)
+                .filter(StringUtils::isNotBlank)
+                .orElse(CodegenUtils.getDefaultPackageImportName(symbol.getNamespace()));
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -27,23 +27,25 @@ public enum GoDependency implements SymbolDependencyContainer {
     // The version in the stdlib dependencies should reflect the minimum Go version.
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
-    BIG("stdlib", "", "math/big", "1.14"),
-    TIME("stdlib", "", "time", "1.14"),
-    FMT("stdlib", "", "fmt", "1.14"),
-    CONTEXT("stdlib", "", "context", "1.14"),
+    BIG("stdlib", "", "math/big", null, "1.14"),
+    TIME("stdlib", "", "time", null, "1.14"),
+    FMT("stdlib", "", "fmt", null, "1.14"),
+    CONTEXT("stdlib", "", "context", null, "1.14"),
 
-    SMITHY("dependency", "github.com/awslabs/smithy-go", "github.com/awslabs/smithy-go", "v0.0.1"),
+    SMITHY("dependency", "github.com/awslabs/smithy-go", "github.com/awslabs/smithy-go",
+            "smithy", "v0.0.1"),
     SMITHY_HTTP_TRANSPORT("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/transport/http", "v0.0.1"),
+            "github.com/awslabs/smithy-go/transport/http", "smithyhttp", "v0.0.1"),
     SMITHY_MIDDLEWARE("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/middleware", "v0.0.1");
+            "github.com/awslabs/smithy-go/middleware", null, "v0.0.1");
 
     public final String sourcePath;
     public final String importPath;
+    public final String alias;
     public final String version;
     public final SymbolDependency dependency;
 
-    GoDependency(String type, String sourcePath, String importPath, String version) {
+    GoDependency(String type, String sourcePath, String importPath, String alias, String version) {
         this.dependency = SymbolDependency.builder()
                 .dependencyType(type)
                 .packageName(sourcePath)
@@ -52,6 +54,7 @@ public enum GoDependency implements SymbolDependencyContainer {
         this.sourcePath = sourcePath;
         this.importPath = importPath;
         this.version = version;
+        this.alias = alias;
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -16,30 +16,22 @@
 package software.amazon.smithy.go.codegen;
 
 import java.util.function.BiConsumer;
-
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.codegen.core.SymbolReference;
 
 /**
  * Helper for generating stack step middleware.
  */
 public final class GoStackStepMiddlewareGenerator {
-    private static final SymbolReference CONTEXT_TYPE = SymbolReference.builder()
-            .symbol(SymbolUtils.createValueSymbolBuilder("context.Context")
-                    .addReference(SymbolUtils.createNamespaceReference(GoDependency.CONTEXT))
-                    .build())
-            .build();
-    private static final SymbolReference METADATA_TYPE = SymbolReference.builder()
-            .symbol(SymbolUtils.createValueSymbolBuilder("middleware.Metadata")
-                    .addReference(SymbolUtils.createNamespaceReference(GoDependency.SMITHY_MIDDLEWARE))
-                    .build())
-            .build();
+    private static final Symbol CONTEXT_TYPE = SymbolUtils.createValueSymbolBuilder(
+            "Context", GoDependency.CONTEXT).build();
+    private static final Symbol METADATA_TYPE = SymbolUtils.createValueSymbolBuilder(
+            "Metadata", GoDependency.SMITHY_MIDDLEWARE).build();
 
     private final Symbol middlewareSymbol;
     private final String handleMethodName;
-    private final SymbolReference inputType;
-    private final SymbolReference outputType;
-    private final SymbolReference handlerType;
+    private final Symbol inputType;
+    private final Symbol outputType;
+    private final Symbol handlerType;
 
     /**
      * Creates a new middleware generator with the given builder definition.
@@ -63,9 +55,9 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createSerializeStepMiddleware(String identifier) {
         return createMiddleware(identifier,
                 "HandleSerialize",
-                createSmithyMiddlewarePackageReference("middleware.SerializeInput"),
-                createSmithyMiddlewarePackageReference("middleware.SerializeOutput"),
-                createSmithyMiddlewarePackageReference("middleware.SerializeHandler"));
+                SymbolUtils.createValueSymbolBuilder("SerializeInput", GoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("SerializeOutput", GoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("SerializeHandler", GoDependency.SMITHY_MIDDLEWARE).build());
     }
 
     /**
@@ -77,9 +69,9 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createDeserializeStepMiddleware(String identifier) {
         return createMiddleware(identifier,
                 "HandleDeserialize",
-                createSmithyMiddlewarePackageReference("middleware.DeserializeInput"),
-                createSmithyMiddlewarePackageReference("middleware.DeserializeOutput"),
-                createSmithyMiddlewarePackageReference("middleware.DeserializeHandler"));
+                SymbolUtils.createValueSymbolBuilder("DeserializeInput", GoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("DeserializeOutput", GoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("DeserializeHandler", GoDependency.SMITHY_MIDDLEWARE).build());
     }
 
     /**
@@ -95,9 +87,9 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createMiddleware(
             String identifier,
             String handlerMethodName,
-            SymbolReference inputType,
-            SymbolReference outputType,
-            SymbolReference handlerType
+            Symbol inputType,
+            Symbol outputType,
+            Symbol handlerType
     ) {
         return builder()
                 .identifier(identifier)
@@ -211,7 +203,7 @@ public final class GoStackStepMiddlewareGenerator {
      *
      * @return the input type symbol reference.
      */
-    public SymbolReference getInputType() {
+    public Symbol getInputType() {
         return inputType;
     }
 
@@ -220,7 +212,7 @@ public final class GoStackStepMiddlewareGenerator {
      *
      * @return the output type symbol reference.
      */
-    public SymbolReference getOutputType() {
+    public Symbol getOutputType() {
         return outputType;
     }
 
@@ -229,34 +221,26 @@ public final class GoStackStepMiddlewareGenerator {
      *
      * @return the handler type symbol reference.
      */
-    public SymbolReference getHandlerType() {
+    public Symbol getHandlerType() {
         return handlerType;
     }
 
     /**
-     * Get the context type symbol reference.
+     * Get the context type symbol.
      *
-     * @return the context type symbol reference.
+     * @return the context type symbol.
      */
-    public static SymbolReference getContextType() {
+    public static Symbol getContextType() {
         return CONTEXT_TYPE;
     }
 
     /**
-     * Get the middleware metadata type symbol reference.
+     * Get the middleware metadata type symbol.
      *
-     * @return the middleware metadata type symbol reference.
+     * @return the middleware metadata type symbol.
      */
-    public static SymbolReference getMiddlewareMetadataType() {
+    public static Symbol getMiddlewareMetadataType() {
         return METADATA_TYPE;
-    }
-
-    private static SymbolReference createSmithyMiddlewarePackageReference(String typeName) {
-        return SymbolReference.builder()
-                .symbol(SymbolUtils.createValueSymbolBuilder(typeName)
-                        .addReference(SymbolUtils.createNamespaceReference(GoDependency.SMITHY_MIDDLEWARE))
-                        .build())
-                .build();
     }
 
     /**
@@ -265,9 +249,9 @@ public final class GoStackStepMiddlewareGenerator {
     public static class Builder {
         private String identifier;
         private String handleMethodName;
-        private SymbolReference inputType;
-        private SymbolReference outputType;
-        private SymbolReference handlerType;
+        private Symbol inputType;
+        private Symbol outputType;
+        private Symbol handlerType;
 
         /**
          * Builds the middleware generator.
@@ -306,7 +290,7 @@ public final class GoStackStepMiddlewareGenerator {
          * @param inputType the symbol reference to the input type.
          * @return the builder.
          */
-        public Builder inputType(SymbolReference inputType) {
+        public Builder inputType(Symbol inputType) {
             this.inputType = inputType;
             return this;
         }
@@ -317,7 +301,7 @@ public final class GoStackStepMiddlewareGenerator {
          * @param outputType the symbol reference to the output type.
          * @return the builder.
          */
-        public Builder outputType(SymbolReference outputType) {
+        public Builder outputType(Symbol outputType) {
             this.outputType = outputType;
             return this;
         }
@@ -328,7 +312,7 @@ public final class GoStackStepMiddlewareGenerator {
          * @param handlerType the symbol reference to the handler type.
          * @return the builder.
          */
-        public Builder handlerType(SymbolReference handlerType) {
+        public Builder handlerType(Symbol handlerType) {
             this.handlerType = handlerType;
             return this;
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -80,6 +80,9 @@ final class StructureGenerator implements Runnable {
         Symbol structureSymbol = symbolProvider.toSymbol(shape);
         String interfaceName = structureSymbol.getName() + "Interface";
 
+        writer.addUseImports(GoDependency.SMITHY);
+        writer.addUseImports(GoDependency.FMT);
+
         ErrorTrait errorTrait = shape.expectTrait(ErrorTrait.class);
 
         // Write out the interface for the error

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -274,9 +274,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        return SymbolUtils.createValueSymbolBuilder(shape, "smithy.Document")
-                .addReference(SymbolUtils.createNamespaceReference(GoDependency.SMITHY, "smithy"))
-                .build();
+        return SymbolUtils.createValueSymbolBuilder(shape, "Document", GoDependency.SMITHY).build();
     }
 
     @Override
@@ -286,18 +284,16 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol bigIntegerShape(BigIntegerShape shape) {
-        return createBigSymbol(shape, "big.Int");
+        return createBigSymbol(shape, "Int");
     }
 
     @Override
     public Symbol bigDecimalShape(BigDecimalShape shape) {
-        return createBigSymbol(shape, "big.Float");
+        return createBigSymbol(shape, "Float");
     }
 
     private Symbol createBigSymbol(Shape shape, String symbolName) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, symbolName)
-                .addReference(SymbolUtils.createNamespaceReference(GoDependency.BIG))
-                .build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, symbolName, GoDependency.BIG).build();
     }
 
     @Override
@@ -337,9 +333,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         String name = getDefaultShapeName(shape);
         Symbol.Builder builder = SymbolUtils.createPointableSymbolBuilder(shape, name, typesPackageName);
         if (shape.hasTrait(ErrorTrait.ID)) {
-            builder.definitionFile("./types/errors.go")
-                    .addReference(SymbolUtils.createNamespaceReference(GoDependency.SMITHY, "smithy"))
-                    .addReference(SymbolUtils.createNamespaceReference(GoDependency.FMT));
+            builder.definitionFile("./types/errors.go");
         } else {
             builder.definitionFile("./types/types.go");
         }
@@ -363,8 +357,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol timestampShape(TimestampShape shape) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, "time.Time")
-                .addReference(SymbolUtils.createNamespaceReference(GoDependency.TIME))
-                .build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, "Time", GoDependency.TIME).build();
     }
 }


### PR DESCRIPTION
This updates and fixes the way namespacing is handled, particularly
with regard to aliasing. Previously a SymbolReference was being
created to represent the namespace, but that isn't right since a
namespace isn't an individually referenceable entity. Now the symbol
itself controls how its namespace should be referenced. This ends up
being much more concise to define as an added bonus.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
