### PR TITLE
Add wrapping generated doc string to a fixed length

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -47,10 +47,13 @@ import software.amazon.smithy.utils.StringUtils;
 public final class GoWriter extends CodeWriter {
 
     private static final Logger LOGGER = Logger.getLogger(GoWriter.class.getName());
+    private static final int DEFAULT_DOC_WRAP_LENGTH = 80;
 
     private final String fullPackageName;
     private final ImportDeclarations imports = new ImportDeclarations();
     private final List<SymbolDependency> dependencies = new ArrayList<>();
+
+    private int docWrapLength;
 
     public GoWriter(String fullPackageName) {
         this.fullPackageName = fullPackageName;
@@ -59,6 +62,29 @@ public final class GoWriter extends CodeWriter {
         setIndentText("\t");
         putFormatter('T', new GoSymbolFormatter());
         putFormatter('P', new PointableGoSymbolFormatter());
+
+        this.docWrapLength = DEFAULT_DOC_WRAP_LENGTH;
+    }
+
+    /**
+     * Sets the wrap length of doc strings written.
+     *
+     * @param wrapLength The wrap length of the doc string.
+     * @return Returns the writer.
+     */
+    public GoWriter setDocWrapLength(final int wrapLength) {
+        this.docWrapLength = wrapLength;
+        return this;
+    }
+
+    /**
+     * Sets the wrap length of doc strings written to the default value for the Go writer.
+     *
+     * @return Returns the writer.
+     */
+    public GoWriter setDocWrapLength() {
+        this.docWrapLength = DEFAULT_DOC_WRAP_LENGTH;
+        return this;
     }
 
     /**
@@ -183,7 +209,7 @@ public final class GoWriter extends CodeWriter {
      * @param runnable Runnable that handles actually writing docs with the writer.
      * @return Returns the writer.
      */
-    GoWriter writeDocs(Runnable runnable) {
+    protected GoWriter writeDocs(Runnable runnable) {
         pushState("docs");
         setNewlinePrefix("// ");
         runnable.run();
@@ -201,7 +227,8 @@ public final class GoWriter extends CodeWriter {
      * @return Returns the writer.
      */
     public GoWriter writeDocs(String docs) {
-        writeDocs(() -> write(DocumentationConverter.convert(docs)));
+        String wrappedDoc = StringUtils.wrap(DocumentationConverter.convert(docs), docWrapLength);
+        writeDocs(() -> write(wrappedDoc));
         return this;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -53,7 +53,7 @@ public final class GoWriter extends CodeWriter {
     private final ImportDeclarations imports = new ImportDeclarations();
     private final List<SymbolDependency> dependencies = new ArrayList<>();
 
-    private int docWrapLength;
+    private int docWrapLength = DEFAULT_DOC_WRAP_LENGTH;
 
     public GoWriter(String fullPackageName) {
         this.fullPackageName = fullPackageName;
@@ -62,8 +62,6 @@ public final class GoWriter extends CodeWriter {
         setIndentText("\t");
         putFormatter('T', new GoSymbolFormatter());
         putFormatter('P', new PointableGoSymbolFormatter());
-
-        this.docWrapLength = DEFAULT_DOC_WRAP_LENGTH;
     }
 
     /**
@@ -209,7 +207,7 @@ public final class GoWriter extends CodeWriter {
      * @param runnable Runnable that handles actually writing docs with the writer.
      * @return Returns the writer.
      */
-    protected GoWriter writeDocs(Runnable runnable) {
+    private GoWriter writeDocs(Runnable runnable) {
         pushState("docs");
         setNewlinePrefix("// ");
         runnable.run();


### PR DESCRIPTION
Adds a default wrap length to generated doc strings to improve generated
code documentation's readability.