### PR TITLE
`HttpBindingProtocolGen`: fixes Http binding deserializer bug

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -37,6 +37,7 @@ public enum GoDependency implements SymbolDependencyContainer {
     NET_URL("stdlib", "", "net/url", null, Versions.GO_STDLIB),
     NET_HTTP("stdlib", "", "net/http", null, Versions.GO_STDLIB),
     BYTES("stdlib", "", "bytes", null, Versions.GO_STDLIB),
+    STRINGS("stdlib", "", "strings", null, Versions.GO_STDLIB),
 
     SMITHY("dependency", "github.com/awslabs/smithy-go",
             "github.com/awslabs/smithy-go", "smithy", Versions.SMITHY_GO),


### PR DESCRIPTION
*Description of changes:*
* Adds more simple types to work with protocol-test generation
* Fixes bug causing incorrect go code gen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
