### PR TITLE
Remove error interfaces

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -90,8 +90,11 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 .put("String", "String_")
                 .build();
 
+        model.shapes(StructureShape.class)
+                .filter(this::supportsInheritance)
+                .forEach(this::reserveInterfaceMemberAccessors);
+
         escaper = ReservedWordSymbolProvider.builder()
-                .nameReservedWords(reserveInterfaces(model))
                 .memberReservedWords(reservedWords)
                 // Only escape words when the symbol has a definition file to
                 // prevent escaping intentional references to built-in types.
@@ -110,26 +113,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 .memberReservedWords(ReservedWords.compose(reservedWords, reservedErrorMembers))
                 .escapePredicate((shape, symbol) -> !StringUtils.isEmpty(symbol.getDefinitionFile()))
                 .buildEscaper();
-    }
-
-    /**
-     * Reserves interface names for any structure that supports inheritance.
-     *
-     * <p>For each of these structures, Get* and Has* methods are reserved for their members.
-     *
-     * @param model The model whose inheritable structures should have reserved interfaces.
-     * @return ReservedWords containing all the reserved interface names.
-     */
-    private ReservedWords reserveInterfaces(Model model) {
-        ReservedWordsBuilder builder = new ReservedWordsBuilder();
-        model.shapes(StructureShape.class)
-                .filter(this::supportsInheritance)
-                .forEach(shape -> {
-                    reserveInterfaceMemberAccessors(shape);
-                    String name = getDefaultShapeName(shape) + "Interface";
-                    builder.put(name, escapeWithTrailingUnderscore(name));
-                });
-        return builder.build();
     }
 
     private boolean supportsInheritance(Shape shape) {


### PR DESCRIPTION
This removes generation of error interfaces. Instead, when inheritance
is added we will make heavy use of error.As to get less specific
types.

Example generated error:

```go
// Code generated by smithy-go-codegen DO NOT EDIT.
package types

import (
	"fmt"
	smithy "github.com/awslabs/smithy-go"
)

// Error encountered when no resource could be found.
type NoSuchResource struct {
	Message *string

	ResourceType *string
}

func (e *NoSuchResource) Error() string {
	return fmt.Sprintf("%s: %s", e.ErrorCode(), e.ErrorMessage())
}
func (e *NoSuchResource) ErrorMessage() string {
	if e.Message == nil {
		return ""
	}
	return *e.Message
}
func (e *NoSuchResource) ErrorCode() string { return "NoSuchResource" }
func (e *NoSuchResource) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
func (e *NoSuchResource) GetMessage() string {
	return *e.Message
}
func (e *NoSuchResource) HasMessage() bool {
	return e.Message != nil
}
func (e *NoSuchResource) GetResourceType() string {
	return *e.ResourceType
}
func (e *NoSuchResource) HasResourceType() bool {
	return e.ResourceType != nil
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
