### PR TITLE
Add support for binary streams

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -28,6 +28,6 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-traits:1.0.2")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:1.0.2")
     implementation(project(":smithy-go-codegen"))
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -38,6 +38,7 @@ public enum GoDependency implements SymbolDependencyContainer {
     NET_HTTP("stdlib", "", "net/http", null, Versions.GO_STDLIB),
     BYTES("stdlib", "", "bytes", null, Versions.GO_STDLIB),
     STRINGS("stdlib", "", "strings", null, Versions.GO_STDLIB),
+    IO("stdlib", "", "io", null, Versions.GO_STDLIB),
 
     SMITHY("dependency", "github.com/awslabs/smithy-go",
             "github.com/awslabs/smithy-go", "smithy", Versions.SMITHY_GO),

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -103,7 +103,8 @@ final class OperationGenerator implements Runnable {
 
         // Write out the input and output structures. These are written out here to prevent naming conflicts with other
         // shapes in the model.
-        new StructureGenerator(model, symbolProvider, writer, inputShape, inputSymbol).run();
+        new StructureGenerator(model, symbolProvider, writer, inputShape, inputSymbol)
+                .renderStructure(() -> { }, true);
 
         // The output structure gets a metadata member added.
         Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder(

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -73,12 +73,28 @@ final class StructureGenerator implements Runnable {
      *     additional members.
      */
     public void renderStructure(Runnable runnable) {
+        renderStructure(runnable, false);
+    }
+
+    /**
+     * Renders a non-error structure.
+     *
+     * @param runnable A runnable that runs before the structure definition is closed. This can be used to write
+     *     additional members.
+     * @param isInputStructure A boolean indicating if input variants for member symbols should be used.
+     */
+    public void renderStructure(Runnable runnable, boolean isInputStructure) {
         writer.writeShapeDocs(shape);
         writer.openBlock("type $L struct {", symbol.getName());
         for (MemberShape member : shape.getAllMembers().values()) {
             String memberName = symbolProvider.toMemberName(member);
             writer.writeMemberDocs(model, member);
-            writer.write("$L $P", memberName, symbolProvider.toSymbol(member));
+
+            Symbol memberSymbol = symbolProvider.toSymbol(member);
+            if (isInputStructure) {
+                memberSymbol = memberSymbol.getProperty(SymbolUtils.INPUT_VARIANT, Symbol.class).orElse(memberSymbol);
+            }
+            writer.write("$L $P", memberName, memberSymbol);
         }
         runnable.run();
         writer.closeBlock("}").write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
@@ -29,6 +29,9 @@ public final class SymbolUtils {
     public static final String GO_SLICE = "slice";
     public static final String GO_MAP = "map";
 
+    // Used when a given shape must be represented differently on input.
+    public static final String INPUT_VARIANT = "inputVariant";
+
     private SymbolUtils() {
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -58,6 +58,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -199,6 +200,12 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol blobShape(BlobShape shape) {
+        if (shape.hasTrait(StreamingTrait.ID)) {
+            Symbol inputVariant = SymbolUtils.createValueSymbolBuilder(shape, "Reader", GoDependency.IO).build();
+            return SymbolUtils.createValueSymbolBuilder(shape, "ReadCloser", GoDependency.IO)
+                    .putProperty(SymbolUtils.INPUT_VARIANT, inputVariant)
+                    .build();
+        }
         return SymbolUtils.createPointableSymbolBuilder(shape, "[]byte")
                 .putProperty(SymbolUtils.GO_UNIVERSE_TYPE, true)
                 .build();


### PR DESCRIPTION
This adds support for the `streaming` trait on blob shapes. An `io.Reader` will be generated on input and an `io.ReadCloser` will be generated on output.

This also updates the test service to not depend on AWS traits, adding a faux protocol complete with a handful of protocol tests. It also adds event streams and references to shapes that weren't referenced before.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
