### PR TITLE
Fix nested slice and map shape generation

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
@@ -26,8 +26,9 @@ public final class SymbolUtils {
     public static final String POINTABLE = "pointable";
     public static final String NAMESPACE_ALIAS = "namespaceAlias";
     public static final String GO_UNIVERSE_TYPE = "universeType";
-    public static final String GO_SLICE = "slice";
-    public static final String GO_MAP = "map";
+    public static final String GO_SLICE = "goSlice";
+    public static final String GO_MAP = "goMap";
+    public static final String GO_ELEMENT_TYPE = "goElementType";
 
     // Used when a given shape must be represented differently on input.
     public static final String INPUT_VARIANT = "inputVariant";

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -233,7 +233,9 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     private Symbol createCollectionSymbol(CollectionShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return SymbolUtils.createValueSymbolBuilder(shape, shape.getId().getName())
+        // Shape name will be unused for symbols that represent a slice, but in the event it does we set the collection
+        // shape's name to make debugging simpler.
+        return SymbolUtils.createValueSymbolBuilder(shape, getDefaultShapeName(shape))
                 .putProperty(SymbolUtils.GO_SLICE, true)
                 .putProperty(SymbolUtils.GO_UNIVERSE_TYPE,
                         reference.getProperty(SymbolUtils.GO_UNIVERSE_TYPE, Boolean.class).orElse(false))
@@ -244,7 +246,9 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol mapShape(MapShape shape) {
         Symbol reference = toSymbol(shape.getValue());
-        return SymbolUtils.createValueSymbolBuilder(shape, shape.getId().getName())
+        // Shape name will be unused for symbols that represent a map, but in the event it does we set the map shape's
+        // name to make debugging simpler.
+        return SymbolUtils.createValueSymbolBuilder(shape, getDefaultShapeName(shape))
                 .putProperty(SymbolUtils.GO_MAP, true)
                 .putProperty(SymbolUtils.GO_UNIVERSE_TYPE,
                         reference.getProperty(SymbolUtils.GO_UNIVERSE_TYPE, Boolean.class).orElse(false))

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -233,22 +233,22 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     private Symbol createCollectionSymbol(CollectionShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return SymbolUtils.createValueSymbolBuilder(shape, reference.getName(), reference.getNamespace())
+        return SymbolUtils.createValueSymbolBuilder(shape, shape.getId().getName())
                 .putProperty(SymbolUtils.GO_SLICE, true)
                 .putProperty(SymbolUtils.GO_UNIVERSE_TYPE,
                         reference.getProperty(SymbolUtils.GO_UNIVERSE_TYPE, Boolean.class).orElse(false))
-                .addDependency(reference)
+                .putProperty(SymbolUtils.GO_ELEMENT_TYPE, reference)
                 .build();
     }
 
     @Override
     public Symbol mapShape(MapShape shape) {
         Symbol reference = toSymbol(shape.getValue());
-        return SymbolUtils.createValueSymbolBuilder(shape, reference.getName(), reference.getNamespace())
+        return SymbolUtils.createValueSymbolBuilder(shape, shape.getId().getName())
                 .putProperty(SymbolUtils.GO_MAP, true)
                 .putProperty(SymbolUtils.GO_UNIVERSE_TYPE,
                         reference.getProperty(SymbolUtils.GO_UNIVERSE_TYPE, Boolean.class).orElse(false))
-                .addDependency(reference)
+                .putProperty(SymbolUtils.GO_ELEMENT_TYPE, reference)
                 .build();
     }
 


### PR DESCRIPTION
Fixes the generation of maps and slices when nested in other map or slice types.

```go
type KitchenSink struct {
	Blob *[]byte
	Boolean *bool
	Double *float64
	EmptyStruct *EmptyStruct
	Float *float32
	HttpdateTimestamp *time.Time
	Integer *int32
	Iso8601Timestamp *time.Time
	JsonValue *string
	ListOfLists [][]*string
	ListOfMapsOfStrings []map[string]*string
	ListOfStrings []*string
	ListOfStructs []*SimpleStruct
	Long *int64
	MapOfListsOfStrings map[string][]*string
	MapOfMaps map[string]map[string]*string
	MapOfStrings map[string]*string
	MapOfStructs map[string]*SimpleStruct
	RecursiveList []*KitchenSink
	RecursiveMap map[string]*KitchenSink
	RecursiveStruct *KitchenSink
	SimpleStruct *SimpleStruct
	String_ *string
	StructWithLocationName *StructWithLocationName
	Timestamp *time.Time
	UnixTimestamp *time.Time
}
```