### PR TITLE
Generate Smithy byte as Go int8

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -254,7 +254,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol byteShape(ByteShape shape) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, "byte").build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, "int8").build();
     }
 
     @Override


### PR DESCRIPTION
Originally a smithy byte shape was being generated as a Go byte, which is a type alias of a unit8. This change will now generate Smithy byte shape as a int8.