### PR TITLE
Fix issue with empty synthetic type generating into types package.

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -195,7 +195,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     @Override
     public Void structureShape(StructureShape shape) {
-        if (shape.hasTrait(SyntheticClone.ID)) {
+        if (shape.getId().getNamespace().equals(CodegenUtils.getSyntheticTypeNamespace())) {
             return null;
         }
         Symbol symbol = symbolProvider.toSymbol(shape);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -110,7 +110,9 @@ final class OperationGenerator implements Runnable {
         Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder(
                 "Metadata", GoDependency.SMITHY_MIDDLEWARE).build();
         new StructureGenerator(model, symbolProvider, writer, outputShape, outputSymbol).renderStructure(() -> {
-            writer.write("");
+            if (outputShape.getMemberNames().size() != 0) {
+                writer.write("");
+            }
             writer.writeDocs("Metadata pertaining to the operation's result.");
             writer.write("ResultMetadata $T", metadataSymbol);
         });


### PR DESCRIPTION
Fixes the check used for synthetic shapes, as generated input/output shapes for operations that did not model them were incorrectly being generated into the types package.