### PR TITLE
Adds document binding deserializers and middleware generation support

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -174,6 +174,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             writers.useFileWriter("deserializers.go", settings.getModuleName(), writer -> {
                 context.setWriter(writer);
                 protocolGenerator.generateResponseDeserializers(context);
+                protocolGenerator.generateSharedDeserializerComponents(context);
             });
         }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -26,6 +26,8 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 public enum GoDependency implements SymbolDependencyContainer {
 
     // The version in the stdlib dependencies should reflect the minimum Go version.
+
+    // The version in the stdlib dependencies should reflect the minimum Go version.
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
     BIG("stdlib", "", "math/big", null, Versions.GO_STDLIB),
@@ -38,7 +40,9 @@ public enum GoDependency implements SymbolDependencyContainer {
     NET_HTTP("stdlib", "", "net/http", null, Versions.GO_STDLIB),
     BYTES("stdlib", "", "bytes", null, Versions.GO_STDLIB),
     STRINGS("stdlib", "", "strings", null, Versions.GO_STDLIB),
+    JSON("stdlib", "", "encoding/json", null, Versions.GO_STDLIB),
     IO("stdlib", "", "io", null, Versions.GO_STDLIB),
+    IOUTIL("stdlib", "",  "io/ioutil", null, Versions.GO_STDLIB),
 
     SMITHY("dependency", "github.com/awslabs/smithy-go",
             "github.com/awslabs/smithy-go", "smithy", Versions.SMITHY_GO),
@@ -52,7 +56,9 @@ public enum GoDependency implements SymbolDependencyContainer {
     AWS_PRIVATE_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
             "github.com/aws/aws-sdk-go-v2/private/protocol", null, Versions.AWS_SDK),
     AWS_JSON_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
-            "github.com/aws/aws-sdk-go-v2/aws/protocol/json", null, Versions.AWS_SDK);
+            "github.com/aws/aws-sdk-go-v2/aws/protocol/json", null, Versions.AWS_SDK),
+    AWS_JSON_PROTOCOL_ALIAS("dependency", "github.com/aws/aws-sdk-go-v2",
+            "github.com/aws/aws-sdk-go-v2/aws/protocol/json", "jsonprotocol", Versions.AWS_SDK);
 
     public final String sourcePath;
     public final String importPath;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -48,6 +48,8 @@ public enum GoDependency implements SymbolDependencyContainer {
             "github.com/awslabs/smithy-go/transport/http", "smithyhttp", Versions.SMITHY_GO),
     SMITHY_MIDDLEWARE("dependency", "github.com/awslabs/smithy-go",
             "github.com/awslabs/smithy-go/middleware", null, Versions.SMITHY_GO),
+    SMITHY_TIME("dependency", "github.com/awslabs/smithy-go",
+            "github.com/awslabs/smithy-go/time", "smithytime", Versions.SMITHY_GO),
 
     AWS_REST_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
             "github.com/aws/aws-sdk-go-v2/aws/protocol/rest", null, Versions.AWS_SDK),

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -26,8 +26,6 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 public enum GoDependency implements SymbolDependencyContainer {
 
     // The version in the stdlib dependencies should reflect the minimum Go version.
-
-    // The version in the stdlib dependencies should reflect the minimum Go version.
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
     BIG("stdlib", "", "math/big", null, Versions.GO_STDLIB),

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -353,8 +353,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("");
 
             // Output shape HTTP binding middleware generation
-            boolean withRestBindings = isShapeWithRestResponseBindings(model, operation);
-            if (withRestBindings) {
+            if (isShapeWithRestResponseBindings(model, operation)) {
                 String deserFuncName = ProtocolGenerator.getOperationHttpBindingsDeserFunctionName(
                         outputShape, getProtocolName());
 
@@ -367,11 +366,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             }
 
             // Output Shape Document Binding middleware generation
-            boolean withPayloadBindings = isShapeWithResponseBindings(model, operation,
-                    HttpBinding.Location.PAYLOAD);
-            boolean withDocumentBindings = isShapeWithResponseBindings(model, operation,
-                    HttpBinding.Location.DOCUMENT);
-            if (withDocumentBindings || withPayloadBindings) {
+            if (isShapeWithResponseBindings(model, operation, HttpBinding.Location.DOCUMENT)
+                    || isShapeWithResponseBindings(model, operation, HttpBinding.Location.PAYLOAD)) {
                 writeMiddlewareDocumentDeserializerDelegator(writer, model, symbolProvider, operation, generator);
                 writer.write("");
             }
@@ -454,8 +450,14 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         return false;
     }
 
-    // returns whether a Shape has Rest response bindings.
-    // The shape can be an operation shape, error shape or an output shape.
+    /**
+     * Returns whether a shape has rest response bindings.
+     * The shape can be an operation shape, error shape or an output shape.
+     *
+     * @param model          the model
+     * @param shape          the shape with possible presence of rest response bindings
+     * @return boolean indicating presence of rest response bindings in the shape
+     */
     protected boolean isShapeWithRestResponseBindings(Model model, Shape shape) {
         Collection<HttpBinding> bindings = model.getKnowledge(HttpBindingIndex.class)
                 .getResponseBindings(shape).values();
@@ -468,8 +470,15 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         return false;
     }
 
-    // returns whether a shape has response binding for the provided HttpBinding location.
-    // The shape can be an operation shape, error shape or an output shape.
+    /**
+     * Returns whether a shape has response bindings for the provided HttpBinding location.
+     * The shape can be an operation shape, error shape or an output shape.
+     *
+     * @param model          the model
+     * @param shape          the shape with possible presence of response bindings
+     * @param location       the HttpBinding location for response binding
+     * @return boolean indicating presence of response bindings in the shape for provided location
+     */
     protected boolean isShapeWithResponseBindings(Model model, Shape shape, HttpBinding.Location location) {
         Collection<HttpBinding> bindings = model.getKnowledge(HttpBindingIndex.class)
                 .getResponseBindings(shape).values();
@@ -642,19 +651,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     throw new CodegenException("unexpected http binding found");
             }
         });
-    }
-
-    protected boolean isDereferenceRequired(Shape shape, Symbol symbol) {
-        boolean pointable = symbol.getProperty(SymbolUtils.POINTABLE, Boolean.class)
-                .orElse(false);
-
-        ShapeType shapeType = shape.getType();
-
-        return pointable
-                || shapeType == ShapeType.MAP
-                || shapeType == ShapeType.LIST
-                || shapeType == ShapeType.SET
-                || shapeType == ShapeType.DOCUMENT;
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -423,7 +423,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * @param symbolProvider the symbol provider
      * @param operation      the operation
      * @param generator      middleware generator definition
-     * @param writer         the writer within the middlware context
+     * @param writer         the writer within the middleware context
      */
      protected void writeMiddlewareErrorDeserializer(
             GoWriter writer,

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -133,6 +133,14 @@ public interface ProtocolGenerator {
     void generateRequestSerializers(GenerationContext context);
 
     /**
+     * Generates any standard code for service response deserialization.
+     *
+     * @param context Serde context.
+     */
+    default void generateSharedDeserializerComponents(GenerationContext context) {
+    }
+
+    /**
      * Generates the code used to deserialize the shapes of a service
      * for responses.
      *
@@ -193,25 +201,23 @@ public interface ProtocolGenerator {
     /**
      * Generates the name of a deserializer function for shapes of a service.
      *
-     * @param symbol        The symbol the deserializer function is being generated for.
-     * @param protocol      Name of the protocol being generated.
-     * @param protocolLayer the layer of the protocol being generated
+     * @param shape    The shape the deserializer function is being generated for.
+     * @param protocol Name of the protocol being generated.
      * @return Returns the generated function name.
      */
-    static String getDeserFunctionName(Symbol symbol, String protocol, String protocolLayer) {
-        // e.g., awsRestJson1_serializeRestFooShape
-        String functionName = ProtocolGenerator.getSanitizedName(protocol)
-                + "_deserialize"
-                + ProtocolGenerator.getSanitizedName(protocolLayer);
-
-        functionName += symbol.getName();
-
-        return functionName;
+    static String getDocumentDeserializerFunctionName(Shape shape, String protocol) {
+        return protocol + "_deserializeDocument" + StringUtils.capitalize(shape.getId().getName());
     }
 
     static String getSerializeMiddlewareName(ShapeId operationShapeId, String protocol) {
         return protocol
                 + "_serializeOp"
+                + operationShapeId.getName();
+    }
+
+    static String getDeserializeMiddlewareName(ShapeId operationShapeId, String protocol) {
+        return protocol
+                + "_deserializeOp"
                 + operationShapeId.getName();
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -208,6 +208,17 @@ public interface ProtocolGenerator {
         return protocol + "_deserializeDocument" + StringUtils.capitalize(shape.getId().getName());
     }
 
+    /**
+     * Generates the name of a deserializer function for an output shape of a service.
+     *
+     * @param shape    The shape the deserializer function is being generated for.
+     * @param protocol Name of the protocol being generated.
+     * @return Returns the generated function name.
+     */
+    static String getDocumentOutputDeserializerFunctionName(Shape shape, String protocol) {
+        return protocol + "_deserializeOpDocument" + StringUtils.capitalize(shape.getId().getName());
+    }
+
     static String getSerializeMiddlewareName(ShapeId operationShapeId, String protocol) {
         return protocol
                 + "_serializeOp"

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.GoSettings;
@@ -177,14 +176,14 @@ public interface ProtocolGenerator {
     /**
      * Generates the name of a deserializer function for shapes of a service.
      *
-     * @param symbol   The symbol the deserializer function is being generated for.
+     * @param shape    The shape the deserializer function is being generated for.
      * @param protocol Name of the protocol being generated.
      * @return Returns the generated function name.
      */
-    static String getOperationDeserFunctionName(Symbol symbol, String protocol) {
+    static String getOperationHttpBindingsDeserFunctionName(Shape shape, String protocol) {
         return protocol
                 + "_deserializeHttpBindings"
-                + symbol.getName();
+                + StringUtils.capitalize(shape.getId().getName());
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
* Adds rest json deserializer generation support
* Adds rest json deserializer middleware generation support

Related to aws/aws-sdk-go-v2#568


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
