### PR TITLE
Update Smithy document types for embedded vs inline

### DIFF
--- a/document/doc.go
+++ b/document/doc.go
@@ -1,10 +1,3 @@
 // Package document provides utilities to marshal and unmarshal Smithy Document
 // types to an from Go types.
 package document
-
-// Unmarshaler provides an abstract representation of document based values
-// like JSON and Ion. The Unmarshal method will attempt to unmarshal the
-// underlying document's value into the Go type provided.
-type Unmarshaler interface {
-	UnmarshalDocument(interface{}) error
-}

--- a/document/embedded.go
+++ b/document/embedded.go
@@ -1,0 +1,19 @@
+package document
+
+import "io"
+
+// Embedded provides an abstract representation of a serialized document value.
+type Embedded interface {
+	// Attempts to unmarshal the serialized document. If the media type is
+	// unknown, or the unmarshal fails, an error will be returned.
+	//
+	// Returns MediaTypeUnknownError if the media type of the document is
+	// unknown.
+	UnmarshalDocument(interface{}) error
+
+	// Returns the media type of the document.
+	MediaType() string
+
+	// Returns a reader to get the bytes of the serialized document.
+	DocumentReader() io.Reader
+}

--- a/document/value.go
+++ b/document/value.go
@@ -1,0 +1,55 @@
+package document
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Value provides an interface for encapsulating arbitrary Go values within an
+// API protocol agnostic document.
+type Value interface {
+	// Attempts to unmarshal the document value into the Go type provided. Will
+	// panic if the provided value is not a pointer type.
+	UnmarshalDocument(interface{}) error
+
+	// GetValue returns the underlying document value.
+	GetValue() (interface{}, error)
+}
+
+// LazyValue provides a generic wrapper for Go values that are serialized into
+// API parameters.
+type LazyValue struct {
+	Value interface{}
+}
+
+// NewLazyValue returns an initialized LazyValue wrapping the provided
+// Go value.
+func NewLazyValue(v interface{}) LazyValue {
+	return LazyValue{
+		Value: v,
+	}
+}
+
+// UnmarshalDocument attempts to convert the wrapped value into the Go type
+// provided.
+//
+// Will panic if the provided value is not a pointer type.
+func (d LazyValue) UnmarshalDocument(t interface{}) error {
+	// TODO need document type generic unmarshaling behavior.
+
+	blob, err := json.Marshal(d.Value)
+	if err != nil {
+		return fmt.Errorf("unable to convert document value, %w", err)
+	}
+
+	if err := json.Unmarshal(blob, t); err != nil {
+		return fmt.Errorf("unable to convert document value, %w", err)
+	}
+
+	return nil
+}
+
+// GetValue returns the underlying document value.
+func (d LazyValue) GetValue() (interface{}, error) {
+	return d.Value, nil
+}


### PR DESCRIPTION
Updates the Smithy document utilities to reflect the difference between
embedded document values that have a fixed media type, and inline
document values that are serialized inline into a API's protocol
document.

Updates document interfaces used by API parameters:
```go
// Value provides an interface for encapsulating arbitrary Go values within an
// API protocol agnostic document.
type Value interface {
	// Attempts to unmarshal the document value into the Go type provided. Will
	// panic if the provided value is not a pointer type.
	UnmarshalDocument(interface{}) error

	// GetValue returns the underlying document value.
	GetValue() (interface{}, error)
}

// Embedded provides an abstract representation of a serialized document value.
type Embedded interface {
	// Attempts to unmarshal the serialized document. If the media type is
	// unknown, or the unmarshal fails, an error will be returned.
	//
	// Returns MediaTypeUnknownError if the media type of the document is
	// unknown.
	UnmarshalDocument(interface{}) error

	// Returns the media type of the document.
	MediaType() string

	// Returns a reader to get the bytes of the serialized document.
	DocumentReader() io.Reader
}
```

Example API operation input/output parameters:
```go
type OpInput struct {
	ADoc document.Value  // inline document shape
	EnvDoc document.Embedded   // enveloped document shape
}
type OpOutput struct {
	ADoc document.Value // inline document shape
	EnvDoc document.Embedded   // enveloped document shape
}
```

User calls an API operation, passing in document values for ADoc and EnvDoc.
```go
result, err := client.Op(ctx, &OpInput{
	ADoc: document.NewLazyValue(struct{
		Foo string
		Bar string
	} {
		Foo: "abc", Bar: "123",
	}),

	EnvDoc: document.JSONBytes([]byte{`{"First": "red", "Second": "blue"}`}),
	// alternative with struct value:
	EnvDoc: document.NewLazyJSONValue(struct{
		First string
		Second string
	} {
		First: "red", Second: "blue",
	})
})
```

Customer retrieves the result of the API call, makes a modification, then round trips them:
```go
var adoc map[string]string
err := result.ADoc.UnmarshalDocument(&adoc)

// update the deserialized doc
adoc["Foo"] = "to the moon"

var envdoc struct {
	First string
	Second string
}
err := result.EnvDoc.UnmarshalDocuemnt(&envdoc)

// update the deserialized doc
envdoc.First = "mars!"


// Round trip the updated values into another API call
client.Op(ctx, &OpInput{
	ADoc: document.NewLazyDocument(adoc),
	EnvDoc: document.NewLazyJSON(envdoc),
})
```