### PR TITLE
Fixup private/protocol import path in GoDependency

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -50,7 +50,7 @@ public enum GoDependency implements SymbolDependencyContainer {
     AWS_REST_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
             "github.com/aws/aws-sdk-go-v2/aws/protocol/rest", null, Versions.AWS_SDK),
     AWS_PRIVATE_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
-            "github.com/aws/aws-sdk-go-v2/aws/private/protocol", null, Versions.AWS_SDK),
+            "github.com/aws/aws-sdk-go-v2/private/protocol", null, Versions.AWS_SDK),
     AWS_JSON_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
             "github.com/aws/aws-sdk-go-v2/aws/protocol/json", null, Versions.AWS_SDK);
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -694,7 +694,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         binding.getLocation(),
                         Format.HTTP_DATE
                 );
-                writer.write(String.format("t, err := protocol.parseTime(protocol.%s, %s)",
+                writer.write(String.format("t, err := protocol.ParseTime(protocol.%s, %s)",
                         CodegenUtils.getTimeStampFormatName(format), operand));
                 writer.write("if err != nil { return err }");
                 return "t";


### PR DESCRIPTION
GoDependency was referring to the wrong import path for SDK's private/protocol package.