### PR TITLE
Use version ranges for Smithy dependencies

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -28,6 +28,6 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:1.0.2")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.0.2,1.1.0[")
     implementation(project(":smithy-go-codegen"))
 }

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -18,7 +18,7 @@ extra["displayName"] = "Smithy :: Go :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:1.0.2")
+    api("software.amazon.smithy:smithy-codegen-core:[1.0.2,1.1.0[")
     api("com.atlassian.commonmark:commonmark:0.14.0")
     api("org.jsoup:jsoup:1.13.1")
 }


### PR DESCRIPTION
This updates the dependencies on smithy to use a range across the
current minor version. This will let us pick up any new patch
versions without having to manually update every time.

Range dependencies can be very dangerous, but in this case it's only
on a dependency that we control and the range is fairly tight.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
