### PR TITLE
Fix bug placing some I/O shapes in the wrong file

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -353,7 +353,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol structureShape(StructureShape shape) {
         String name = getDefaultShapeName(shape);
-        if (shape.hasTrait(SyntheticClone.ID)) {
+        if (shape.getId().getNamespace().equals(CodegenUtils.getSyntheticTypeNamespace())) {
             Optional<String> boundOperationName = getNameOfBoundOperation(shape);
             if (boundOperationName.isPresent()) {
                 return SymbolUtils.createPointableSymbolBuilder(shape, name, rootModuleName)


### PR DESCRIPTION
The SymbolVisitor was improperly detecting synthetic shapes when they
were generated fresh rather than being clones of existing shapes.
Now the namespace of the shape is checked rather than the presence of
the synthetic clone trait.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
