### PR TITLE
Swap go.mod and gofmt execution so module is created first.

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -182,11 +182,11 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         List<SymbolDependency> dependencies = writers.getDependencies();
         writers.flushWriters();
 
-        LOGGER.fine("Running go fmt");
-        CodegenUtils.runCommand("go fmt", fileManifest.getBaseDir());
-
         LOGGER.fine("Generating go.mod file");
         GoModGenerator.writeGoMod(settings, fileManifest, SymbolDependency.gatherDependencies(dependencies.stream()));
+
+        LOGGER.fine("Running go fmt");
+        CodegenUtils.runCommand("go fmt", fileManifest.getBaseDir());
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -85,7 +85,7 @@ public enum GoDependency implements SymbolDependencyContainer {
 
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
-        private static final String SMITHY_GO = "v0.0.1";
+        private static final String SMITHY_GO = "latest";
         private static final String AWS_SDK = "v0.22.0";
 
     }


### PR DESCRIPTION
Fixes the gofmt failing because of the go.mod not defining the API client's module yet.

Also updates smithy-go pkg dependency to be `latest` until smithy releases a tagged version. Non-existent tagged version breaks gofmt/gomod.