### PR TITLE
`codegen`: adds operation middlewares into middleware stack 

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -236,9 +236,10 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
             for (OperationShape operation : containedOperations) {
                 Symbol operationSymbol = symbolProvider.toSymbol(operation);
+
                 writers.useShapeWriter(operation, operationWriter -> new OperationGenerator(
                         settings, model, symbolProvider, operationWriter, service, operation,
-                        operationSymbol, applicationProtocol, protocolGenerator).run());
+                        operationSymbol, applicationProtocol, protocolGenerator, integrations).run());
             }
         });
         return null;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -238,7 +238,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 Symbol operationSymbol = symbolProvider.toSymbol(operation);
                 writers.useShapeWriter(operation, operationWriter -> new OperationGenerator(
                         settings, model, symbolProvider, operationWriter, service, operation,
-                        operationSymbol, applicationProtocol).run());
+                        operationSymbol, applicationProtocol, protocolGenerator).run());
             }
         });
         return null;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -62,7 +62,13 @@ public enum GoDependency implements SymbolDependencyContainer {
     AWS_REST_JSON_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
             "github.com/aws/aws-sdk-go-v2/aws/protocol/restjson", null, Versions.AWS_SDK),
     AWS_PRIVATE_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
-            "github.com/aws/aws-sdk-go-v2/private/protocol", null, Versions.AWS_SDK);
+            "github.com/aws/aws-sdk-go-v2/private/protocol", null, Versions.AWS_SDK),
+    AWS_MIDDLEWARE("dependency", "github.com/aws/aws-sdk-go-v2",
+            "github.com/aws/aws-sdk-go-v2/aws/middleware", "awsmiddleware", Versions.AWS_SDK),
+    AWS_RETRY_MIDDLEWARE("dependency", "github.com/aws/aws-sdk-go-v2",
+                        "github.com/aws/aws-sdk-go-v2/aws/retry", null, Versions.AWS_SDK),
+    AWS_V4SIGNER_MIDDLEWARE("dependency", "github.com/aws/aws-sdk-go-v2",
+            "github.com/aws/aws-sdk-go-v2/aws/signer/v4", null, Versions.AWS_SDK);
 
     public final String sourcePath;
     public final String importPath;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -154,13 +154,15 @@ final class OperationGenerator implements Runnable {
      */
     private void populateOperationMiddlewareStack() {
         writer.write("");
+        // add serializer middleware
         String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(operation.getId(),
                 protocolGenerator.getProtocolName());
-        writer.write("stack.Serialize.Add($L{}, middleware.After)", serializerMiddlewareName);
+        writer.write("stack.Serialize.Add(&$L{}, middleware.After)", serializerMiddlewareName);
 
+        // add deserializer middleware
         String deserializerMiddlewareName = ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(),
                 protocolGenerator.getProtocolName());
-        writer.write("stack.Deserialize.Add($L{}, middleware.After)", deserializerMiddlewareName);
+        writer.write("stack.Deserialize.Add(&$L{}, middleware.After)", deserializerMiddlewareName);
         writer.write("");
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -172,7 +172,7 @@ final class OperationGenerator implements Runnable {
         }
 
         for (GoIntegration integration: integrations) {
-            integration.assembleMiddlewareStack(settings, model, symbolProvider, writer, operation);
+            integration.assembleMiddlewareStack(settings, model, symbolProvider, writer, service, operation);
         }
 
         writer.write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.go.codegen;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -37,6 +38,7 @@ final class OperationGenerator implements Runnable {
     private final OperationShape operation;
     private final Symbol operationSymbol;
     private final ApplicationProtocol applicationProtocol;
+    private final ProtocolGenerator protocolGenerator;
 
     OperationGenerator(
             GoSettings settings,
@@ -46,7 +48,8 @@ final class OperationGenerator implements Runnable {
             ServiceShape service,
             OperationShape operation,
             Symbol operationSymbol,
-            ApplicationProtocol applicationProtocol
+            ApplicationProtocol applicationProtocol,
+            ProtocolGenerator protocolGenerator
     ) {
         this.settings = settings;
         this.model = model;
@@ -56,6 +59,7 @@ final class OperationGenerator implements Runnable {
         this.operation = operation;
         this.operationSymbol = operationSymbol;
         this.applicationProtocol = applicationProtocol;
+        this.protocolGenerator = protocolGenerator;
     }
 
     @Override
@@ -92,8 +96,12 @@ final class OperationGenerator implements Runnable {
                         writer.write("if err := fn(stack); err != nil { return nil, err }");
                     });
 
-                    constructHandler();
+                    if (protocolGenerator != null) {
+                        // add middleware to operation stack
+                        populateOperationMiddlewareStack();
+                    }
 
+                    constructHandler();
                     writer.write("result, metadata, err := handler.Handle(ctx, params)");
                     writer.write("if err != nil { return nil, err }");
                     writer.write("out := result.($P)", outputSymbol);
@@ -138,5 +146,21 @@ final class OperationGenerator implements Runnable {
         Symbol newClientHandler = SymbolUtils.createValueSymbolBuilder(
                 "NewClientHandler", GoDependency.SMITHY_HTTP_TRANSPORT).build();
         writer.write("handler := $T($T(options.HTTPClient), stack)", decorateHandler, newClientHandler);
+    }
+
+
+    /**
+     * populateOperationMiddlewareStack adds middleware to the operation middleware stack.
+     */
+    private void populateOperationMiddlewareStack() {
+        writer.write("");
+        String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(operation.getId(),
+                protocolGenerator.getProtocolName());
+        writer.write("stack.Serialize.Add($L{}, middleware.After)", serializerMiddlewareName);
+
+        String deserializerMiddlewareName = ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(),
+                protocolGenerator.getProtocolName());
+        writer.write("stack.Deserialize.Add($L{}, middleware.After)", deserializerMiddlewareName);
+        writer.write("");
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.go.codegen;
 
+import java.util.List;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
@@ -39,6 +41,7 @@ final class OperationGenerator implements Runnable {
     private final Symbol operationSymbol;
     private final ApplicationProtocol applicationProtocol;
     private final ProtocolGenerator protocolGenerator;
+    private final List<GoIntegration> integrations;
 
     OperationGenerator(
             GoSettings settings,
@@ -49,7 +52,8 @@ final class OperationGenerator implements Runnable {
             OperationShape operation,
             Symbol operationSymbol,
             ApplicationProtocol applicationProtocol,
-            ProtocolGenerator protocolGenerator
+            ProtocolGenerator protocolGenerator,
+            List<GoIntegration> integrations
     ) {
         this.settings = settings;
         this.model = model;
@@ -60,6 +64,7 @@ final class OperationGenerator implements Runnable {
         this.operationSymbol = operationSymbol;
         this.applicationProtocol = applicationProtocol;
         this.protocolGenerator = protocolGenerator;
+        this.integrations = integrations;
     }
 
     @Override
@@ -96,10 +101,8 @@ final class OperationGenerator implements Runnable {
                         writer.write("if err := fn(stack); err != nil { return nil, err }");
                     });
 
-                    if (protocolGenerator != null) {
-                        // add middleware to operation stack
-                        populateOperationMiddlewareStack();
-                    }
+                    // add middleware to operation stack
+                    populateOperationMiddlewareStack();
 
                     constructHandler();
                     writer.write("result, metadata, err := handler.Handle(ctx, params)");
@@ -154,15 +157,26 @@ final class OperationGenerator implements Runnable {
      */
     private void populateOperationMiddlewareStack() {
         writer.write("");
-        // add serializer middleware
-        String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(operation.getId(),
-                protocolGenerator.getProtocolName());
-        writer.write("stack.Serialize.Add(&$L{}, middleware.After)", serializerMiddlewareName);
 
-        // add deserializer middleware
-        String deserializerMiddlewareName = ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(),
-                protocolGenerator.getProtocolName());
-        writer.write("stack.Deserialize.Add(&$L{}, middleware.After)", deserializerMiddlewareName);
+        // protocol specific middleware generation
+        if (protocolGenerator != null) {
+            // add serializer middleware
+            String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(operation.getId(),
+                    protocolGenerator.getProtocolName());
+            writer.write("stack.Serialize.Add(&$L{}, middleware.After)", serializerMiddlewareName);
+
+            // add deserializer middleware
+            String deserializerMiddlewareName = ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(),
+                    protocolGenerator.getProtocolName());
+            writer.write("stack.Deserialize.Add(&$L{}, middleware.After)", deserializerMiddlewareName);
+        }
+
+        for (GoIntegration integration: integrations) {
+            integration.assembleMiddlewareStack(settings, model, symbolProvider, writer, operation);
+        }
+
         writer.write("");
+
     }
+
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 
 
@@ -122,13 +123,15 @@ public interface GoIntegration {
      * @param model Model to generate from.
      * @param symbolProvider Symbol provider used for codegen.
      * @param writer Writer that will be used.
-     * @param operationShape Operation Shape that is being defined in the writer.
+     * @param serviceShape Service shape of the operation.
+     * @param operationShape Operation Shape for which middleware stack is populated.
      */
     default void assembleMiddlewareStack(
             GoSettings settings,
             Model model,
             SymbolProvider symbolProvider,
             GoWriter writer,
+            ServiceShape serviceShape,
             OperationShape operationShape
     ) {
         // pass

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 
 
@@ -107,6 +108,28 @@ public interface GoIntegration {
             SymbolProvider symbolProvider,
             GoWriter writer,
             Shape definedShape
+    ) {
+        // pass
+    }
+
+    /**
+     * Populates operation middleware stack.
+     *
+     * This method is used to populate middleware stack inside
+     * the operation function.
+     *
+     * @param settings Settings used to generate.
+     * @param model Model to generate from.
+     * @param symbolProvider Symbol provider used for codegen.
+     * @param writer Writer that will be used.
+     * @param operationShape Operation Shape that is being defined in the writer.
+     */
+    default void assembleMiddlewareStack(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoWriter writer,
+            OperationShape operationShape
     ) {
         // pass
     }


### PR DESCRIPTION
*Description of changes:*
* Adds Operation middleware for retry, signer into middleware stack
* Related to aws/aws-sdk-go-v2#586
* Contains #66 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
