### PR TITLE
Refactor GoDependency and Dependency Constants

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ApplicationProtocol.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ApplicationProtocol.java
@@ -60,7 +60,8 @@ public final class ApplicationProtocol {
     }
 
     private static Symbol createHttpSymbol(String symbolName) {
-        return SymbolUtils.createPointableSymbolBuilder(symbolName, GoDependency.SMITHY_HTTP_TRANSPORT)
+        return SymbolUtils.createPointableSymbolBuilder(symbolName,
+                SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency())
                 .build();
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ApplicationProtocol.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ApplicationProtocol.java
@@ -60,8 +60,7 @@ public final class ApplicationProtocol {
     }
 
     private static Symbol createHttpSymbol(String symbolName) {
-        return SymbolUtils.createPointableSymbolBuilder(symbolName,
-                SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency())
+        return SymbolUtils.createPointableSymbolBuilder(symbolName, SmithyGoDependency.SMITHY_HTTP_TRANSPORT)
                 .build();
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -32,7 +32,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumTrait;
-import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -198,27 +197,8 @@ public final class CodegenUtils {
                 return operand;
         }
 
-        writer.addUseImports(GoDependency.SMITHY_PTR);
+        writer.addUseImports(SmithyGoDependency.SMITHY_PTR.getDependency());
         return prefix + operand + suffix;
-    }
-
-    /**
-     * Get SDK equivalent timestamp format name for TimestampFormatTrait.Format enum.
-     *
-     * @param format The format is TimestampFormatTrait.Format enum
-     * @return SDK equivalent timestamp format name
-     */
-    public static String getTimeStampFormatName(TimestampFormatTrait.Format format) {
-        switch (format) {
-            case DATE_TIME:
-                return "ISO8601TimeFormatName";
-            case EPOCH_SECONDS:
-                return "UnixTimeFormatName";
-            case HTTP_DATE:
-                return "RFC822TimeFormat";
-            default:
-                throw new CodegenException("unknown timestamp format found: " + format.toString());
-        }
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -197,7 +197,7 @@ public final class CodegenUtils {
                 return operand;
         }
 
-        writer.addUseImports(SmithyGoDependency.SMITHY_PTR.getDependency());
+        writer.addUseImports(SmithyGoDependency.SMITHY_PTR);
         return prefix + operand + suffix;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -15,82 +15,233 @@
 
 package software.amazon.smithy.go.codegen;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
 
-/**
- * An enum of all the built-in dependencies used by this package.
- */
-public enum GoDependency implements SymbolDependencyContainer {
+public final class GoDependency implements SymbolDependencyContainer, Comparable<GoDependency> {
+    private final Type type;
+    private final String sourcePath;
+    private final String importPath;
+    private final String alias;
+    private final String version;
+    private final Set<GoDependency> dependencies;
+    private final SymbolDependency symbolDependency;
 
-    // The version in the stdlib dependencies should reflect the minimum Go version.
-    // The values aren't currently used, but they could potentially used to dynamically
-    // set the minimum go version.
-    BIG("stdlib", "", "math/big", null, Versions.GO_STDLIB),
-    TIME("stdlib", "", "time", null, Versions.GO_STDLIB),
-    FMT("stdlib", "", "fmt", null, Versions.GO_STDLIB),
-    CONTEXT("stdlib", "", "context", null, Versions.GO_STDLIB),
-    STRCONV("stdlib", "", "strconv", null, Versions.GO_STDLIB),
-    BASE64("stdlib", "", "encoding/base64", null, Versions.GO_STDLIB),
-    NET_URL("stdlib", "", "net/url", null, Versions.GO_STDLIB),
-    NET_HTTP("stdlib", "", "net/http", null, Versions.GO_STDLIB),
-    BYTES("stdlib", "", "bytes", null, Versions.GO_STDLIB),
-    STRINGS("stdlib", "", "strings", null, Versions.GO_STDLIB),
-    JSON("stdlib", "", "encoding/json", null, Versions.GO_STDLIB),
-    IO("stdlib", "", "io", null, Versions.GO_STDLIB),
-    IOUTIL("stdlib", "",  "io/ioutil", null, Versions.GO_STDLIB),
+    private GoDependency(Builder builder) {
+        this.type = SmithyBuilder.requiredState("type", builder.type);
+        this.sourcePath = !this.type.equals(Type.STANDARD_LIBRARY)
+                ? SmithyBuilder.requiredState("sourcePath", builder.sourcePath) : "";
+        this.importPath = SmithyBuilder.requiredState("importPath", builder.importPath);
+        this.alias = builder.alias;
+        this.version = SmithyBuilder.requiredState("version", builder.version);
+        this.dependencies = builder.dependencies;
 
-    SMITHY("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go", "smithy", Versions.SMITHY_GO),
-    SMITHY_HTTP_TRANSPORT("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/transport/http", "smithyhttp", Versions.SMITHY_GO),
-    SMITHY_MIDDLEWARE("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/middleware", null, Versions.SMITHY_GO),
-    SMITHY_TIME("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/time", "smithytime", Versions.SMITHY_GO),
-    SMITHY_HTTP_BINDING("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/httpbinding", null, Versions.SMITHY_GO),
-    SMITHY_JSON("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/json", "smithyjson", Versions.SMITHY_GO),
-    SMITHY_IO("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/io", "smithyio", Versions.SMITHY_GO),
-    SMITHY_PTR("dependency", "github.com/awslabs/smithy-go",
-            "github.com/awslabs/smithy-go/ptr", null, Versions.SMITHY_GO),
-
-    AWS_REST_JSON_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
-            "github.com/aws/aws-sdk-go-v2/aws/protocol/restjson", null, Versions.AWS_SDK),
-    AWS_PRIVATE_PROTOCOL("dependency", "github.com/aws/aws-sdk-go-v2",
-            "github.com/aws/aws-sdk-go-v2/private/protocol", null, Versions.AWS_SDK);
-
-    public final String sourcePath;
-    public final String importPath;
-    public final String alias;
-    public final String version;
-    public final SymbolDependency dependency;
-
-    GoDependency(String type, String sourcePath, String importPath, String alias, String version) {
-        this.dependency = SymbolDependency.builder()
-                .dependencyType(type)
-                .packageName(sourcePath)
-                .version(version)
+        this.symbolDependency = SymbolDependency.builder()
+                .dependencyType(this.type.toString())
+                .packageName(this.sourcePath)
+                .version(this.version)
                 .build();
-        this.sourcePath = sourcePath;
-        this.importPath = importPath;
-        this.version = version;
-        this.alias = alias;
+    }
+
+    public Set<GoDependency> getGoDependencies() {
+        return this.dependencies;
+    }
+
+    public SymbolDependency getSymbolDependency() {
+        return symbolDependency;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getSourcePath() {
+        return sourcePath;
+    }
+
+    public String getImportPath() {
+        return importPath;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     @Override
     public List<SymbolDependency> getDependencies() {
-        return Collections.singletonList(dependency);
+        Set<SymbolDependency> symbolDependencySet = new TreeSet<>(SetUtils.of(getSymbolDependency()));
+
+        symbolDependencySet.addAll(resolveDependencies(getGoDependencies(), new TreeSet<>(SetUtils.of(this))));
+
+        return new ArrayList<>(symbolDependencySet);
     }
 
-    private static final class Versions {
-        private static final String GO_STDLIB = "1.14";
-        private static final String SMITHY_GO = "v0.0.0-20200604194311-25e885347bc8";
-        private static final String AWS_SDK = "v0.0.0-20200608172716-6b3036355dc9";
-        private static final String GO_CMP = "v0.4.1";
+    private Set<SymbolDependency> resolveDependencies(Set<GoDependency> goDependencies, Set<GoDependency> processed) {
+        Set<SymbolDependency> symbolDependencies = new TreeSet<>();
+        if (goDependencies.size() == 0) {
+            return symbolDependencies;
+        }
+
+        Set<GoDependency> dependenciesToResolve = new TreeSet<>();
+        for (GoDependency dependency : goDependencies) {
+            if (processed.contains(dependency)) {
+                continue;
+            }
+            processed.add(dependency);
+            symbolDependencies.add(dependency.getSymbolDependency());
+            dependenciesToResolve.addAll(dependency.getGoDependencies());
+        }
+
+        symbolDependencies.addAll(resolveDependencies(dependenciesToResolve, processed));
+
+        return symbolDependencies;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof GoDependency)) {
+            return false;
+        }
+
+        GoDependency other = (GoDependency) o;
+
+        return this.type.equals(other.type) && this.sourcePath.equals(other.sourcePath)
+                && this.importPath.equals(other.importPath) && this.alias.equals(other.alias)
+                && this.version.equals(other.version) && this.dependencies.equals(other.dependencies);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, sourcePath, importPath, alias, version, dependencies);
+    }
+
+    @Override
+    public int compareTo(GoDependency o) {
+        if (equals(o)) {
+            return 0;
+        }
+
+        int importPathCompare = importPath.compareTo(o.importPath);
+        if (importPathCompare != 0) {
+            return importPathCompare;
+        }
+
+        if (alias != null) {
+            return alias.compareTo(o.alias);
+        }
+
+        return version.compareTo(o.version);
+    }
+
+    public enum Type {
+        STANDARD_LIBRARY, DEPENDENCY;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case STANDARD_LIBRARY:
+                    return "stdlib";
+                case DEPENDENCY:
+                    return "dependency";
+                default:
+                    return "unknown";
+            }
+        }
+    }
+
+    public static GoDependency moduleDependency(String sourcePath, String importPath, String version, String alias) {
+        GoDependency.Builder builder = GoDependency.builder()
+                .type(GoDependency.Type.DEPENDENCY)
+                .sourcePath(sourcePath)
+                .importPath(importPath)
+                .version(version);
+        if (alias != null) {
+            builder.alias(alias);
+        }
+        return builder.build();
+    }
+
+    public static GoDependency standardLibraryDependency(String importPath, String version) {
+        return GoDependency.builder()
+                .type(GoDependency.Type.STANDARD_LIBRARY)
+                .importPath(importPath)
+                .version(version)
+                .build();
+    }
+
+    public static final class Builder implements SmithyBuilder<GoDependency> {
+        private Type type;
+        private String sourcePath;
+        private String importPath;
+        private String alias;
+        private String version;
+        private final Set<GoDependency> dependencies = new TreeSet<>();
+
+        private Builder() {
+        }
+
+        public Builder type(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder sourcePath(String sourcePath) {
+            this.sourcePath = sourcePath;
+            return this;
+        }
+
+        public Builder importPath(String importPath) {
+            this.importPath = importPath;
+            return this;
+        }
+
+        public Builder alias(String alias) {
+            this.alias = alias;
+            return this;
+        }
+
+        public Builder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder dependencies(Collection<GoDependency> dependencies) {
+            this.dependencies.clear();
+            this.dependencies.addAll(dependencies);
+            return this;
+        }
+
+        public Builder addDependency(GoDependency dependency) {
+            this.dependencies.add(dependency);
+            return this;
+        }
+
+        public Builder removeDependency(GoDependency dependency) {
+            this.dependencies.remove(dependency);
+            return this;
+        }
+
+        @Override
+        public GoDependency build() {
+            return new GoDependency(this);
+        }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoDependency.java
@@ -26,6 +26,9 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 
+/**
+ *
+ */
 public final class GoDependency implements SymbolDependencyContainer, Comparable<GoDependency> {
     private final Type type;
     private final String sourcePath;
@@ -51,30 +54,65 @@ public final class GoDependency implements SymbolDependencyContainer, Comparable
                 .build();
     }
 
+    /**
+     * Get the the set of {@link GoDependency} required by this dependency.
+     *
+     * @return the set of dependencies
+     */
     public Set<GoDependency> getGoDependencies() {
         return this.dependencies;
     }
 
+    /**
+     * Get the symbol dependency representing the dependency.
+     *
+     * @return the symbol dependency
+     */
     public SymbolDependency getSymbolDependency() {
         return symbolDependency;
     }
 
+    /**
+     * Get the type of dependency.
+     *
+     * @return the dependency type
+     */
     public Type getType() {
         return type;
     }
 
+    /**
+     * Get the source code path of the dependency.
+     *
+     * @return the dependency source code path
+     */
     public String getSourcePath() {
         return sourcePath;
     }
 
+    /**
+     * Get the import path of the dependency.
+     *
+     * @return the import path of the dependency
+     */
     public String getImportPath() {
         return importPath;
     }
 
+    /**
+     * Get the alias of the module to use.
+     *
+     * @return the alias
+     */
     public String getAlias() {
         return alias;
     }
 
+    /**
+     * Get the version of the dependency.
+     *
+     * @return the version
+     */
     public String getVersion() {
         return version;
     }
@@ -145,12 +183,18 @@ public final class GoDependency implements SymbolDependencyContainer, Comparable
         }
 
         if (alias != null) {
-            return alias.compareTo(o.alias);
+            int aliasCompare = alias.compareTo(o.alias);
+            if (aliasCompare != 0) {
+                return aliasCompare;
+            }
         }
 
         return version.compareTo(o.version);
     }
 
+    /**
+     * Represents a dependency type.
+     */
     public enum Type {
         STANDARD_LIBRARY, DEPENDENCY;
 
@@ -167,6 +211,15 @@ public final class GoDependency implements SymbolDependencyContainer, Comparable
         }
     }
 
+    /**
+     * Get {@link GoDependency} representing the provided module description.
+     *
+     * @param sourcePath the root source path for the given code
+     * @param importPath the import path of the package
+     * @param version    the version of source module
+     * @param alias      a default alias to use when importing the package, can be null
+     * @return the dependency
+     */
     public static GoDependency moduleDependency(String sourcePath, String importPath, String version, String alias) {
         GoDependency.Builder builder = GoDependency.builder()
                 .type(GoDependency.Type.DEPENDENCY)
@@ -179,6 +232,13 @@ public final class GoDependency implements SymbolDependencyContainer, Comparable
         return builder.build();
     }
 
+    /**
+     * Get {@link GoDependency} representing the standard library import description.
+     *
+     * @param importPath the import path of the package
+     * @param version    the version of source module
+     * @return the dependency
+     */
     public static GoDependency standardLibraryDependency(String importPath, String version) {
         return GoDependency.builder()
                 .type(GoDependency.Type.STANDARD_LIBRARY)
@@ -187,6 +247,9 @@ public final class GoDependency implements SymbolDependencyContainer, Comparable
                 .build();
     }
 
+    /**
+     * Builder for {@link GoDependency}.
+     */
     public static final class Builder implements SmithyBuilder<GoDependency> {
         private Type type;
         private String sourcePath;
@@ -198,42 +261,90 @@ public final class GoDependency implements SymbolDependencyContainer, Comparable
         private Builder() {
         }
 
+        /**
+         * Set the dependency type.
+         *
+         * @param type dependency type
+         * @return the builder
+         */
         public Builder type(Type type) {
             this.type = type;
             return this;
         }
 
+        /**
+         * Set the source path.
+         *
+         * @param sourcePath the source path root
+         * @return the builder
+         */
         public Builder sourcePath(String sourcePath) {
             this.sourcePath = sourcePath;
             return this;
         }
 
+        /**
+         * Set the import path.
+         *
+         * @param importPath the import path
+         * @return the builder
+         */
         public Builder importPath(String importPath) {
             this.importPath = importPath;
             return this;
         }
 
+        /**
+         * Set the dependency alias.
+         *
+         * @param alias the alias
+         * @return the builder
+         */
         public Builder alias(String alias) {
             this.alias = alias;
             return this;
         }
 
+        /**
+         * Set the dependency version.
+         *
+         * @param version the version
+         * @return the builder
+         */
         public Builder version(String version) {
             this.version = version;
             return this;
         }
 
+        /**
+         * Set the collection of {@link GoDependency} required by this dependency.
+         *
+         * @param dependencies a collection of dependencies
+         * @return the builder
+         */
         public Builder dependencies(Collection<GoDependency> dependencies) {
             this.dependencies.clear();
             this.dependencies.addAll(dependencies);
             return this;
         }
 
+        /**
+         * Add a dependency on another {@link GoDependency}.
+         *
+         * @param dependency the dependency
+         * @return the builder
+         */
         public Builder addDependency(GoDependency dependency) {
             this.dependencies.add(dependency);
             return this;
         }
 
+        /**
+         * Remove a dependency on another {@link GoDependency}.
+         *
+         * @param dependency the dependency
+         * @return the builder
+         */
         public Builder removeDependency(GoDependency dependency) {
             this.dependencies.remove(dependency);
             return this;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -23,9 +23,9 @@ import software.amazon.smithy.codegen.core.Symbol;
  */
 public final class GoStackStepMiddlewareGenerator {
     private static final Symbol CONTEXT_TYPE = SymbolUtils.createValueSymbolBuilder(
-            "Context", GoDependency.CONTEXT).build();
+            "Context", SmithyGoDependency.CONTEXT.getDependency()).build();
     private static final Symbol METADATA_TYPE = SymbolUtils.createValueSymbolBuilder(
-            "Metadata", GoDependency.SMITHY_MIDDLEWARE).build();
+            "Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
 
     private final Symbol middlewareSymbol;
     private final String handleMethodName;
@@ -55,9 +55,12 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createSerializeStepMiddleware(String identifier) {
         return createMiddleware(identifier,
                 "HandleSerialize",
-                SymbolUtils.createValueSymbolBuilder("SerializeInput", GoDependency.SMITHY_MIDDLEWARE).build(),
-                SymbolUtils.createValueSymbolBuilder("SerializeOutput", GoDependency.SMITHY_MIDDLEWARE).build(),
-                SymbolUtils.createValueSymbolBuilder("SerializeHandler", GoDependency.SMITHY_MIDDLEWARE).build());
+                SymbolUtils.createValueSymbolBuilder("SerializeInput",
+                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
+                SymbolUtils.createValueSymbolBuilder("SerializeOutput",
+                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
+                SymbolUtils.createValueSymbolBuilder("SerializeHandler",
+                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build());
     }
 
     /**
@@ -69,9 +72,12 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createDeserializeStepMiddleware(String identifier) {
         return createMiddleware(identifier,
                 "HandleDeserialize",
-                SymbolUtils.createValueSymbolBuilder("DeserializeInput", GoDependency.SMITHY_MIDDLEWARE).build(),
-                SymbolUtils.createValueSymbolBuilder("DeserializeOutput", GoDependency.SMITHY_MIDDLEWARE).build(),
-                SymbolUtils.createValueSymbolBuilder("DeserializeHandler", GoDependency.SMITHY_MIDDLEWARE).build());
+                SymbolUtils.createValueSymbolBuilder("DeserializeInput",
+                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
+                SymbolUtils.createValueSymbolBuilder("DeserializeOutput",
+                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
+                SymbolUtils.createValueSymbolBuilder("DeserializeHandler",
+                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build());
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -23,9 +23,9 @@ import software.amazon.smithy.codegen.core.Symbol;
  */
 public final class GoStackStepMiddlewareGenerator {
     private static final Symbol CONTEXT_TYPE = SymbolUtils.createValueSymbolBuilder(
-            "Context", SmithyGoDependency.CONTEXT.getDependency()).build();
+            "Context", SmithyGoDependency.CONTEXT).build();
     private static final Symbol METADATA_TYPE = SymbolUtils.createValueSymbolBuilder(
-            "Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
+            "Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE).build();
 
     private final Symbol middlewareSymbol;
     private final String handleMethodName;
@@ -55,12 +55,9 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createSerializeStepMiddleware(String identifier) {
         return createMiddleware(identifier,
                 "HandleSerialize",
-                SymbolUtils.createValueSymbolBuilder("SerializeInput",
-                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
-                SymbolUtils.createValueSymbolBuilder("SerializeOutput",
-                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
-                SymbolUtils.createValueSymbolBuilder("SerializeHandler",
-                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build());
+                SymbolUtils.createValueSymbolBuilder("SerializeInput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("SerializeOutput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("SerializeHandler", SmithyGoDependency.SMITHY_MIDDLEWARE).build());
     }
 
     /**
@@ -72,12 +69,10 @@ public final class GoStackStepMiddlewareGenerator {
     public static GoStackStepMiddlewareGenerator createDeserializeStepMiddleware(String identifier) {
         return createMiddleware(identifier,
                 "HandleDeserialize",
-                SymbolUtils.createValueSymbolBuilder("DeserializeInput",
-                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
-                SymbolUtils.createValueSymbolBuilder("DeserializeOutput",
-                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build(),
-                SymbolUtils.createValueSymbolBuilder("DeserializeHandler",
-                        SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build());
+                SymbolUtils.createValueSymbolBuilder("DeserializeInput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("DeserializeOutput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
+                SymbolUtils.createValueSymbolBuilder("DeserializeHandler", SmithyGoDependency.SMITHY_MIDDLEWARE)
+                        .build());
     }
 
     /**
@@ -166,8 +161,8 @@ public final class GoStackStepMiddlewareGenerator {
         // each middleware must implement their given handlerMethodName in order to satisfy the interface for
         // their respective step.
         writer.openBlock("func (m $P) $L(ctx $T, in $T, next $T) (\n"
-                       + "\tout $T, metadata $T, err error,\n"
-                       + ") {", "}",
+                        + "\tout $T, metadata $T, err error,\n"
+                        + ") {", "}",
                 new Object[]{
                         middlewareSymbol, handleMethodName, CONTEXT_TYPE, inputType, handlerType, outputType,
                         METADATA_TYPE,

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -120,7 +120,7 @@ public final class GoWriter extends CodeWriter {
      */
     public GoWriter addUseImports(GoDependency goDependency) {
         dependencies.addAll(goDependency.getDependencies());
-        return addImport(goDependency.importPath, goDependency.alias);
+        return addImport(goDependency.getImportPath(), goDependency.getAlias());
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -79,8 +79,7 @@ final class OperationGenerator implements Runnable {
         Symbol outputSymbol = symbolProvider.toSymbol(outputShape);
 
         writer.writeShapeDocs(operation);
-        Symbol contextSymbol = SymbolUtils.createValueSymbolBuilder("Context",
-                SmithyGoDependency.CONTEXT.getDependency()).build();
+        Symbol contextSymbol = SymbolUtils.createValueSymbolBuilder("Context", SmithyGoDependency.CONTEXT).build();
         writer.openBlock("func (c $P) $T(ctx $T, params $P, optFns ...func(*Options)) ($P, error) {", "}",
                 serviceSymbol, operationSymbol, contextSymbol, inputSymbol, outputSymbol, () -> {
                     constructStack();
@@ -116,8 +115,8 @@ final class OperationGenerator implements Runnable {
                 }, true);
 
         // The output structure gets a metadata member added.
-        Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder(
-                "Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
+        Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder("Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE)
+                .build();
         new StructureGenerator(model, symbolProvider, writer, outputShape, outputSymbol).renderStructure(() -> {
             if (outputShape.getMemberNames().size() != 0) {
                 writer.write("");
@@ -132,8 +131,8 @@ final class OperationGenerator implements Runnable {
             throw new UnsupportedOperationException(
                     "Protocols other than HTTP are not yet implemented: " + applicationProtocol);
         }
-        writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency());
-        writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency());
+        writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
+        writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
         writer.write("stack := middleware.NewStack($S, smithyhttp.NewStackRequest)", operationSymbol.getName());
     }
 
@@ -143,9 +142,9 @@ final class OperationGenerator implements Runnable {
                     "Protocols other than HTTP are not yet implemented: " + applicationProtocol);
         }
         Symbol decorateHandler = SymbolUtils.createValueSymbolBuilder(
-                "DecorateHandler", SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
+                "DecorateHandler", SmithyGoDependency.SMITHY_MIDDLEWARE).build();
         Symbol newClientHandler = SymbolUtils.createValueSymbolBuilder(
-                "NewClientHandler", SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency()).build();
+                "NewClientHandler", SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build();
         writer.write("handler := $T($T(options.HTTPClient), stack)", decorateHandler, newClientHandler);
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -79,7 +79,8 @@ final class OperationGenerator implements Runnable {
         Symbol outputSymbol = symbolProvider.toSymbol(outputShape);
 
         writer.writeShapeDocs(operation);
-        Symbol contextSymbol = SymbolUtils.createValueSymbolBuilder("Context", GoDependency.CONTEXT).build();
+        Symbol contextSymbol = SymbolUtils.createValueSymbolBuilder("Context",
+                SmithyGoDependency.CONTEXT.getDependency()).build();
         writer.openBlock("func (c $P) $T(ctx $T, params $P, optFns ...func(*Options)) ($P, error) {", "}",
                 serviceSymbol, operationSymbol, contextSymbol, inputSymbol, outputSymbol, () -> {
                     constructStack();
@@ -116,7 +117,7 @@ final class OperationGenerator implements Runnable {
 
         // The output structure gets a metadata member added.
         Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder(
-                "Metadata", GoDependency.SMITHY_MIDDLEWARE).build();
+                "Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
         new StructureGenerator(model, symbolProvider, writer, outputShape, outputSymbol).renderStructure(() -> {
             if (outputShape.getMemberNames().size() != 0) {
                 writer.write("");
@@ -131,8 +132,8 @@ final class OperationGenerator implements Runnable {
             throw new UnsupportedOperationException(
                     "Protocols other than HTTP are not yet implemented: " + applicationProtocol);
         }
-        writer.addUseImports(GoDependency.SMITHY_MIDDLEWARE);
-        writer.addUseImports(GoDependency.SMITHY_HTTP_TRANSPORT);
+        writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency());
+        writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency());
         writer.write("stack := middleware.NewStack($S, smithyhttp.NewStackRequest)", operationSymbol.getName());
     }
 
@@ -142,9 +143,9 @@ final class OperationGenerator implements Runnable {
                     "Protocols other than HTTP are not yet implemented: " + applicationProtocol);
         }
         Symbol decorateHandler = SymbolUtils.createValueSymbolBuilder(
-                "DecorateHandler", GoDependency.SMITHY_MIDDLEWARE).build();
+                "DecorateHandler", SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
         Symbol newClientHandler = SymbolUtils.createValueSymbolBuilder(
-                "NewClientHandler", GoDependency.SMITHY_HTTP_TRANSPORT).build();
+                "NewClientHandler", SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency()).build();
         writer.write("handler := $T($T(options.HTTPClient), stack)", decorateHandler, newClientHandler);
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -96,7 +96,7 @@ final class OperationGenerator implements Runnable {
 
                     writer.write("result, metadata, err := handler.Handle(ctx, params)");
                     writer.openBlock("if err != nil {", "}", () -> {
-                        writer.addUseImports(GoDependency.SMITHY);
+                        writer.addUseImports(SmithyGoDependency.SMITHY);
                         writer.openBlock("return nil, &smithy.OperationError{", "}", () -> {
                             writer.write("ServiceID: c.ServiceID(),");
                             writer.write("OperationName: \"$T\",", operationSymbol);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -83,7 +83,8 @@ final class ServiceGenerator implements Runnable {
 
         generateConfig();
 
-        Symbol stackSymbol = SymbolUtils.createPointableSymbolBuilder("Stack", GoDependency.SMITHY_MIDDLEWARE).build();
+        Symbol stackSymbol = SymbolUtils.createPointableSymbolBuilder("Stack",
+                SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
         writer.write("type $L func($P) error", API_OPTIONS_FUNC_NAME, stackSymbol);
     }
 
@@ -151,7 +152,7 @@ final class ServiceGenerator implements Runnable {
 
     private void generateApplicationProtocolTypes() {
         ensureSupportedProtocol();
-        writer.addUseImports(GoDependency.NET_HTTP);
+        writer.addUseImports(SmithyGoDependency.NET_HTTP.getDependency());
         writer.openBlock("type HTTPClient interface {", "}", () -> {
             writer.write("Do(*http.Request) (*http.Response, error)");
         }).write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -83,8 +83,8 @@ final class ServiceGenerator implements Runnable {
 
         generateConfig();
 
-        Symbol stackSymbol = SymbolUtils.createPointableSymbolBuilder("Stack",
-                SmithyGoDependency.SMITHY_MIDDLEWARE.getDependency()).build();
+        Symbol stackSymbol = SymbolUtils.createPointableSymbolBuilder("Stack", SmithyGoDependency.SMITHY_MIDDLEWARE)
+                .build();
         writer.write("type $L func($P) error", API_OPTIONS_FUNC_NAME, stackSymbol);
     }
 
@@ -152,7 +152,7 @@ final class ServiceGenerator implements Runnable {
 
     private void generateApplicationProtocolTypes() {
         ensureSupportedProtocol();
-        writer.addUseImports(SmithyGoDependency.NET_HTTP.getDependency());
+        writer.addUseImports(SmithyGoDependency.NET_HTTP);
         writer.openBlock("type HTTPClient interface {", "}", () -> {
             writer.write("Do(*http.Request) (*http.Response, error)");
         }).write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -47,10 +47,7 @@ public final class SmithyGoDependency {
 
     private static final String SMITHY_SOURCE_PATH = "github.com/awslabs/smithy-go";
 
-    private final GoDependency dependency;
-
-    SmithyGoDependency(GoDependency dependency) {
-        this.dependency = dependency;
+    private SmithyGoDependency() {
     }
 
     private static GoDependency stdlib(String importPath) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -18,33 +18,32 @@ package software.amazon.smithy.go.codegen;
 /**
  * An enum of all the built-in dependencies used by this package.
  */
-public enum SmithyGoDependency {
-
+public final class SmithyGoDependency {
     // The version in the stdlib dependencies should reflect the minimum Go version.
     // The values aren't currently used, but they could potentially used to dynamically
     // set the minimum go version.
-    BIG(stdlib("math/big")),
-    TIME(stdlib("time")),
-    FMT(stdlib("fmt")),
-    CONTEXT(stdlib("context")),
-    STRCONV(stdlib("strconv")),
-    BASE64(stdlib("encoding/base64")),
-    NET_URL(stdlib("net/url")),
-    NET_HTTP(stdlib("net/http")),
-    BYTES(stdlib("bytes")),
-    STRINGS(stdlib("strings")),
-    JSON(stdlib("encoding/json")),
-    IO(stdlib("io")),
-    IOUTIL(stdlib("io/ioutil")),
+    public static final GoDependency BIG = stdlib("math/big");
+    public static final GoDependency TIME = stdlib("time");
+    public static final GoDependency FMT = stdlib("fmt");
+    public static final GoDependency CONTEXT = stdlib("context");
+    public static final GoDependency STRCONV = stdlib("strconv");
+    public static final GoDependency BASE64 = stdlib("encoding/base64");
+    public static final GoDependency NET_URL = stdlib("net/url");
+    public static final GoDependency NET_HTTP = stdlib("net/http");
+    public static final GoDependency BYTES = stdlib("bytes");
+    public static final GoDependency STRINGS = stdlib("strings");
+    public static final GoDependency JSON = stdlib("encoding/json");
+    public static final GoDependency IO = stdlib("io");
+    public static final GoDependency IOUTIL = stdlib("io/ioutil");
 
-    SMITHY(smithy(null, "smithy")),
-    SMITHY_HTTP_TRANSPORT(smithy("transport/http", "smithyhttp")),
-    SMITHY_MIDDLEWARE(smithy("middleware")),
-    SMITHY_TIME(smithy("time", "smithytime")),
-    SMITHY_HTTP_BINDING(smithy("httpbinding")),
-    SMITHY_JSON(smithy("json", "smithyjson")),
-    SMITHY_IO(smithy("io", "smithyio")),
-    SMITHY_PTR(smithy("ptr"));
+    public static final GoDependency SMITHY = smithy(null, "smithy");
+    public static final GoDependency SMITHY_HTTP_TRANSPORT = smithy("transport/http", "smithyhttp");
+    public static final GoDependency SMITHY_MIDDLEWARE = smithy("middleware");
+    public static final GoDependency SMITHY_TIME = smithy("time", "smithytime");
+    public static final GoDependency SMITHY_HTTP_BINDING = smithy("httpbinding");
+    public static final GoDependency SMITHY_JSON = smithy("json", "smithyjson");
+    public static final GoDependency SMITHY_IO = smithy("io", "smithyio");
+    public static final GoDependency SMITHY_PTR = smithy("ptr");
 
     private static final String SMITHY_SOURCE_PATH = "github.com/awslabs/smithy-go";
 
@@ -52,10 +51,6 @@ public enum SmithyGoDependency {
 
     SmithyGoDependency(GoDependency dependency) {
         this.dependency = dependency;
-    }
-
-    public GoDependency getDependency() {
-        return dependency;
     }
 
     private static GoDependency stdlib(String importPath) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.go.codegen;
 
 /**
- * An enum of all the built-in dependencies used by this package.
+ * A class of constants for dependencies used by this package.
  */
 public final class SmithyGoDependency {
     // The version in the stdlib dependencies should reflect the minimum Go version.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+/**
+ * An enum of all the built-in dependencies used by this package.
+ */
+public enum SmithyGoDependency {
+
+    // The version in the stdlib dependencies should reflect the minimum Go version.
+    // The values aren't currently used, but they could potentially used to dynamically
+    // set the minimum go version.
+    BIG(stdlib("math/big")),
+    TIME(stdlib("time")),
+    FMT(stdlib("fmt")),
+    CONTEXT(stdlib("context")),
+    STRCONV(stdlib("strconv")),
+    BASE64(stdlib("encoding/base64")),
+    NET_URL(stdlib("net/url")),
+    NET_HTTP(stdlib("net/http")),
+    BYTES(stdlib("bytes")),
+    STRINGS(stdlib("strings")),
+    JSON(stdlib("encoding/json")),
+    IO(stdlib("io")),
+    IOUTIL(stdlib("io/ioutil")),
+
+    SMITHY(smithy(null, "smithy")),
+    SMITHY_HTTP_TRANSPORT(smithy("transport/http", "smithyhttp")),
+    SMITHY_MIDDLEWARE(smithy("middleware")),
+    SMITHY_TIME(smithy("time", "smithytime")),
+    SMITHY_HTTP_BINDING(smithy("httpbinding")),
+    SMITHY_JSON(smithy("json", "smithyjson")),
+    SMITHY_IO(smithy("io", "smithyio")),
+    SMITHY_PTR(smithy("ptr"));
+
+    private static final String SMITHY_SOURCE_PATH = "github.com/awslabs/smithy-go";
+
+    private final GoDependency dependency;
+
+    SmithyGoDependency(GoDependency dependency) {
+        this.dependency = dependency;
+    }
+
+    public GoDependency getDependency() {
+        return dependency;
+    }
+
+    private static GoDependency stdlib(String importPath) {
+        return GoDependency.standardLibraryDependency(importPath, Versions.GO_STDLIB);
+    }
+
+    private static GoDependency smithy(String relativePath) {
+        return smithy(relativePath, null);
+    }
+
+    private static GoDependency smithy(String relativePath, String alias) {
+        String importPath = SMITHY_SOURCE_PATH;
+        if (relativePath != null) {
+            importPath = importPath + "/" + relativePath;
+        }
+        return GoDependency.moduleDependency(SMITHY_SOURCE_PATH, importPath, Versions.SMITHY_GO, alias);
+    }
+
+    private static final class Versions {
+        private static final String GO_STDLIB = "1.14";
+        private static final String SMITHY_GO = "v0.0.0-20200604194311-25e885347bc8";
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -105,8 +105,8 @@ final class StructureGenerator implements Runnable {
      */
     private void renderErrorStructure() {
         Symbol structureSymbol = symbolProvider.toSymbol(shape);
-        writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
-        writer.addUseImports(SmithyGoDependency.FMT.getDependency());
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addUseImports(SmithyGoDependency.FMT);
         ErrorTrait errorTrait = shape.expectTrait(ErrorTrait.class);
 
         // Write out a struct to hold the error data.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -105,8 +105,8 @@ final class StructureGenerator implements Runnable {
      */
     private void renderErrorStructure() {
         Symbol structureSymbol = symbolProvider.toSymbol(shape);
-        writer.addUseImports(GoDependency.SMITHY);
-        writer.addUseImports(GoDependency.FMT);
+        writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
+        writer.addUseImports(SmithyGoDependency.FMT.getDependency());
         ErrorTrait errorTrait = shape.expectTrait(ErrorTrait.class);
 
         // Write out a struct to hold the error data.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
@@ -175,9 +175,9 @@ public final class SymbolUtils {
     }
 
     private static Symbol.Builder setImportedNamespace(Symbol.Builder builder, GoDependency dependency) {
-        return builder.namespace(dependency.importPath, ".")
+        return builder.namespace(dependency.getImportPath(), ".")
                 .addDependency(dependency)
-                .putProperty(NAMESPACE_ALIAS, dependency.alias);
+                .putProperty(NAMESPACE_ALIAS, dependency.getAlias());
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -201,8 +201,9 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol blobShape(BlobShape shape) {
         if (shape.hasTrait(StreamingTrait.ID)) {
-            Symbol inputVariant = SymbolUtils.createValueSymbolBuilder(shape, "Reader", GoDependency.IO).build();
-            return SymbolUtils.createValueSymbolBuilder(shape, "ReadCloser", GoDependency.IO)
+            Symbol inputVariant = SymbolUtils.createValueSymbolBuilder(shape, "Reader",
+                    SmithyGoDependency.IO.getDependency()).build();
+            return SymbolUtils.createValueSymbolBuilder(shape, "ReadCloser", SmithyGoDependency.IO.getDependency())
                     .putProperty(SymbolUtils.INPUT_VARIANT, inputVariant)
                     .build();
         }
@@ -291,7 +292,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        return SymbolUtils.createValueSymbolBuilder(shape, "Document", GoDependency.SMITHY).build();
+        return SymbolUtils.createValueSymbolBuilder(shape, "Document",
+                SmithyGoDependency.SMITHY.getDependency()).build();
     }
 
     @Override
@@ -312,7 +314,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private Symbol createBigSymbol(Shape shape, String symbolName) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, symbolName, GoDependency.BIG).build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, symbolName,
+                SmithyGoDependency.BIG.getDependency()).build();
     }
 
     @Override
@@ -399,6 +402,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol timestampShape(TimestampShape shape) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, "Time", GoDependency.TIME).build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, "Time",
+                SmithyGoDependency.TIME.getDependency()).build();
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -201,9 +201,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol blobShape(BlobShape shape) {
         if (shape.hasTrait(StreamingTrait.ID)) {
-            Symbol inputVariant = SymbolUtils.createValueSymbolBuilder(shape, "Reader",
-                    SmithyGoDependency.IO.getDependency()).build();
-            return SymbolUtils.createValueSymbolBuilder(shape, "ReadCloser", SmithyGoDependency.IO.getDependency())
+            Symbol inputVariant = SymbolUtils.createValueSymbolBuilder(shape, "Reader", SmithyGoDependency.IO).build();
+            return SymbolUtils.createValueSymbolBuilder(shape, "ReadCloser", SmithyGoDependency.IO)
                     .putProperty(SymbolUtils.INPUT_VARIANT, inputVariant)
                     .build();
         }
@@ -292,8 +291,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        return SymbolUtils.createValueSymbolBuilder(shape, "Document",
-                SmithyGoDependency.SMITHY.getDependency()).build();
+        return SymbolUtils.createValueSymbolBuilder(shape, "Document", SmithyGoDependency.SMITHY).build();
     }
 
     @Override
@@ -314,8 +312,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private Symbol createBigSymbol(Shape shape, String symbolName) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, symbolName,
-                SmithyGoDependency.BIG.getDependency()).build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, symbolName, SmithyGoDependency.BIG).build();
     }
 
     @Override
@@ -402,7 +399,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol timestampShape(TimestampShape shape) {
-        return SymbolUtils.createPointableSymbolBuilder(shape, "Time",
-                SmithyGoDependency.TIME.getDependency()).build();
+        return SymbolUtils.createPointableSymbolBuilder(shape, "Time", SmithyGoDependency.TIME).build();
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -254,9 +254,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         HttpTrait httpTrait = operation.expectTrait(HttpTrait.class);
 
         middleware.writeMiddleware(context.getWriter(), (generator, writer) -> {
-            writer.addUseImports(SmithyGoDependency.FMT.getDependency());
-            writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
-            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency());
+            writer.addUseImports(SmithyGoDependency.FMT);
+            writer.addUseImports(SmithyGoDependency.SMITHY);
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
 
             // cast input request to smithy transport type, check for failures
             writer.write("request, ok := in.Request.($P)", requestType);
@@ -278,7 +278,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("");
             writer.write("request.Request.URL.Path = $S", httpTrait.getUri());
             writer.write("request.Request.Method = $S", httpTrait.getMethod());
-            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency());
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
             writer.write("restEncoder := httpbinding.NewEncoder(request.Request)");
             writer.write("");
 
@@ -286,7 +286,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             if (isOperationWithRestRequestBindings(model, operation)) {
                 String serFunctionName = ProtocolGenerator.getOperationHttpBindingsSerFunctionName(inputShape,
                         getProtocolName());
-                writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency());
+                writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
                 writer.openBlock("if err := $L(input, restEncoder); err != nil {", "}", serFunctionName, () -> {
                     writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
                 });
@@ -318,7 +318,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         GoWriter goWriter = context.getWriter();
 
         middleware.writeMiddleware(goWriter, (generator, writer) -> {
-            writer.addUseImports(SmithyGoDependency.FMT.getDependency());
+            writer.addUseImports(SmithyGoDependency.FMT);
 
             writer.write("out, metadata, err = next.$L(ctx, in)", generator.getHandleMethodName());
             writer.write("if err != nil { return out, metadata, err }");
@@ -326,7 +326,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             writer.write("response, ok := out.RawResponse.($P)", responseType);
             writer.openBlock("if !ok {", "}", () -> {
-                writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
+                writer.addUseImports(SmithyGoDependency.SMITHY);
                 writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
                         "fmt.Errorf(\"unknown transport type %T\", out.RawResponse)"));
             });
@@ -353,7 +353,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                 writer.write("err= $L(output, response)", deserFuncName);
                 writer.openBlock("if err != nil {", "}", () -> {
-                    writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
+                    writer.addUseImports(SmithyGoDependency.SMITHY);
                     writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
                             "fmt.Errorf(\"failed to decode response with invalid Http bindings, %w\", err)"));
                 });
@@ -509,7 +509,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
         String functionName = ProtocolGenerator.getOperationHttpBindingsSerFunctionName(inputShape, getProtocolName());
 
-        writer.addUseImports(SmithyGoDependency.FMT.getDependency());
+        writer.addUseImports(SmithyGoDependency.FMT);
         writer.openBlock("func $L(v $P, encoder $P) error {", "}", functionName, inputSymbol, restEncoder,
                 () -> {
                     writer.openBlock("if v == nil {", "}", () -> {
@@ -529,8 +529,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     private Symbol getRestEncoderSymbol() {
-        return SymbolUtils.createPointableSymbolBuilder("Encoder",
-                SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency()).build();
+        return SymbolUtils.createPointableSymbolBuilder("Encoder", SmithyGoDependency.SMITHY_HTTP_BINDING).build();
     }
 
     private void generateHttpBindingTimestampSerializer(
@@ -541,7 +540,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             String operand,
             BiConsumer<GoWriter, String> locationEncoder
     ) {
-        writer.addUseImports(SmithyGoDependency.SMITHY_TIME.getDependency());
+        writer.addUseImports(SmithyGoDependency.SMITHY_TIME);
 
         TimestampFormatTrait.Format format = model.getKnowledge(HttpBindingIndex.class).determineTimestampFormat(
                 memberShape, location, getDocumentTimestampFormat());
@@ -828,9 +827,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         Symbol targetSymbol = symbolProvider.toSymbol(targetShape);
         Symbol smithyHttpResponsePointableSymbol = SymbolUtils.createPointableSymbolBuilder(
-                "Response", SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency()).build();
+                "Response", SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build();
 
-        writer.addUseImports(SmithyGoDependency.FMT.getDependency());
+        writer.addUseImports(SmithyGoDependency.FMT);
 
         String functionName = ProtocolGenerator.getOperationHttpBindingsDeserFunctionName(targetShape,
                 getProtocolName());
@@ -875,12 +874,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 }
                 return operand;
             case BOOLEAN:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseBool($L)", operand);
                 writer.write("if err != nil { return err }");
                 return "vv";
             case TIMESTAMP:
-                writer.addUseImports(SmithyGoDependency.SMITHY_TIME.getDependency());
+                writer.addUseImports(SmithyGoDependency.SMITHY_TIME);
                 HttpBindingIndex bindingIndex = model.getKnowledge(HttpBindingIndex.class);
                 TimestampFormatTrait.Format format = bindingIndex.determineTimestampFormat(
                         targetShape,
@@ -889,7 +888,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 );
                 switch (format) {
                     case EPOCH_SECONDS:
-                        writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                        writer.addUseImports(SmithyGoDependency.STRCONV);
                         writer.write("f, err := strconv.ParseFloat($L, 64)", operand);
                         writer.write("if err != nil { return err }");
                         writer.write("t := smithytime.ParseEpochSeconds(f)");
@@ -907,37 +906,37 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 }
                 return "t";
             case BYTE:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseInt($L, 0, 8)", operand);
                 writer.write("if err != nil { return err }");
                 return "int8(vv)";
             case SHORT:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseInt($L, 0, 16)", operand);
                 writer.write("if err != nil { return err }");
                 return "int16(vv)";
             case INTEGER:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseInt($L, 0, 32)", operand);
                 writer.write("if err != nil { return err }");
                 return "int32(vv)";
             case LONG:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseInt($L, 0, 64)", operand);
                 writer.write("if err != nil { return err }");
                 return "vv";
             case FLOAT:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseFloat($L, 32)", operand);
                 writer.write("if err != nil { return err }");
                 return "float32(vv)";
             case DOUBLE:
-                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseFloat($L, 64)", operand);
                 writer.write("if err != nil { return err }");
                 return "vv";
             case BIG_INTEGER:
-                writer.addUseImports(SmithyGoDependency.BIG.getDependency());
+                writer.addUseImports(SmithyGoDependency.BIG);
                 writer.write("i := big.NewInt(0)");
                 writer.write("bi, ok := i.SetString($L,0)", operand);
                 writer.openBlock("if !ok {", "}", () -> {
@@ -948,7 +947,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 });
                 return "*bi";
             case BIG_DECIMAL:
-                writer.addUseImports(SmithyGoDependency.BIG.getDependency());
+                writer.addUseImports(SmithyGoDependency.BIG);
                 writer.write("f := big.NewFloat(0)");
                 writer.write("bd, ok := f.SetString($L,0)", operand);
                 writer.openBlock("if !ok {", "}", () -> {
@@ -959,7 +958,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 });
                 return "*bd";
             case BLOB:
-                writer.addUseImports(SmithyGoDependency.BASE64.getDependency());
+                writer.addUseImports(SmithyGoDependency.BASE64);
                 writer.write("b, err := base64.StdEncoding.DecodeString($L)", operand);
                 writer.write("if err != nil { return err }");
                 return "b";
@@ -987,7 +986,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol targetSymbol = symbolProvider.toSymbol(targetShape);
         writer.write("list := make([]$P, 0, 0)", targetSymbol);
 
-        writer.addUseImports(SmithyGoDependency.STRINGS.getDependency());
+        writer.addUseImports(SmithyGoDependency.STRINGS);
         writer.openBlock("for _, i := range strings.Split($L[1:len($L)-1], $S) {",
                 "}", operand, operand, ",",
                 () -> {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -30,9 +30,9 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.CodegenUtils;
-import software.amazon.smithy.go.codegen.GoDependency;
 import software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator;
 import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.HttpBinding;
@@ -254,9 +254,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         HttpTrait httpTrait = operation.expectTrait(HttpTrait.class);
 
         middleware.writeMiddleware(context.getWriter(), (generator, writer) -> {
-            writer.addUseImports(GoDependency.FMT);
-            writer.addUseImports(GoDependency.SMITHY);
-            writer.addUseImports(GoDependency.SMITHY_HTTP_BINDING);
+            writer.addUseImports(SmithyGoDependency.FMT.getDependency());
+            writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency());
 
             // cast input request to smithy transport type, check for failures
             writer.write("request, ok := in.Request.($P)", requestType);
@@ -278,7 +278,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("");
             writer.write("request.Request.URL.Path = $S", httpTrait.getUri());
             writer.write("request.Request.Method = $S", httpTrait.getMethod());
-            writer.addUseImports(GoDependency.SMITHY_HTTP_BINDING);
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency());
             writer.write("restEncoder := httpbinding.NewEncoder(request.Request)");
             writer.write("");
 
@@ -286,7 +286,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             if (isOperationWithRestRequestBindings(model, operation)) {
                 String serFunctionName = ProtocolGenerator.getOperationHttpBindingsSerFunctionName(inputShape,
                         getProtocolName());
-                writer.addUseImports(GoDependency.SMITHY_HTTP_BINDING);
+                writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency());
                 writer.openBlock("if err := $L(input, restEncoder); err != nil {", "}", serFunctionName, () -> {
                     writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
                 });
@@ -318,7 +318,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         GoWriter goWriter = context.getWriter();
 
         middleware.writeMiddleware(goWriter, (generator, writer) -> {
-            writer.addUseImports(GoDependency.FMT);
+            writer.addUseImports(SmithyGoDependency.FMT.getDependency());
 
             writer.write("out, metadata, err = next.$L(ctx, in)", generator.getHandleMethodName());
             writer.write("if err != nil { return out, metadata, err }");
@@ -326,7 +326,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             writer.write("response, ok := out.RawResponse.($P)", responseType);
             writer.openBlock("if !ok {", "}", () -> {
-                writer.addUseImports(GoDependency.SMITHY);
+                writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
                 writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
                         "fmt.Errorf(\"unknown transport type %T\", out.RawResponse)"));
             });
@@ -353,7 +353,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                 writer.write("err= $L(output, response)", deserFuncName);
                 writer.openBlock("if err != nil {", "}", () -> {
-                    writer.addUseImports(GoDependency.SMITHY);
+                    writer.addUseImports(SmithyGoDependency.SMITHY.getDependency());
                     writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
                             "fmt.Errorf(\"failed to decode response with invalid Http bindings, %w\", err)"));
                 });
@@ -509,7 +509,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
         String functionName = ProtocolGenerator.getOperationHttpBindingsSerFunctionName(inputShape, getProtocolName());
 
-        writer.addUseImports(GoDependency.FMT);
+        writer.addUseImports(SmithyGoDependency.FMT.getDependency());
         writer.openBlock("func $L(v $P, encoder $P) error {", "}", functionName, inputSymbol, restEncoder,
                 () -> {
                     writer.openBlock("if v == nil {", "}", () -> {
@@ -529,7 +529,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     private Symbol getRestEncoderSymbol() {
-        return SymbolUtils.createPointableSymbolBuilder("Encoder", GoDependency.SMITHY_HTTP_BINDING).build();
+        return SymbolUtils.createPointableSymbolBuilder("Encoder",
+                SmithyGoDependency.SMITHY_HTTP_BINDING.getDependency()).build();
     }
 
     private void generateHttpBindingTimestampSerializer(
@@ -540,7 +541,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             String operand,
             BiConsumer<GoWriter, String> locationEncoder
     ) {
-        writer.addUseImports(GoDependency.SMITHY_TIME);
+        writer.addUseImports(SmithyGoDependency.SMITHY_TIME.getDependency());
 
         TimestampFormatTrait.Format format = model.getKnowledge(HttpBindingIndex.class).determineTimestampFormat(
                 memberShape, location, getDocumentTimestampFormat());
@@ -827,9 +828,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         Symbol targetSymbol = symbolProvider.toSymbol(targetShape);
         Symbol smithyHttpResponsePointableSymbol = SymbolUtils.createPointableSymbolBuilder(
-                "Response", GoDependency.SMITHY_HTTP_TRANSPORT).build();
+                "Response", SmithyGoDependency.SMITHY_HTTP_TRANSPORT.getDependency()).build();
 
-        writer.addUseImports(GoDependency.FMT);
+        writer.addUseImports(SmithyGoDependency.FMT.getDependency());
 
         String functionName = ProtocolGenerator.getOperationHttpBindingsDeserFunctionName(targetShape,
                 getProtocolName());
@@ -874,54 +875,69 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 }
                 return operand;
             case BOOLEAN:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseBool($L)", operand);
                 writer.write("if err != nil { return err }");
                 return "vv";
             case TIMESTAMP:
-                writer.addUseImports(GoDependency.AWS_PRIVATE_PROTOCOL);
+                writer.addUseImports(SmithyGoDependency.SMITHY_TIME.getDependency());
                 HttpBindingIndex bindingIndex = model.getKnowledge(HttpBindingIndex.class);
                 TimestampFormatTrait.Format format = bindingIndex.determineTimestampFormat(
                         targetShape,
                         binding.getLocation(),
                         Format.HTTP_DATE
                 );
-                writer.write(String.format("t, err := protocol.ParseTime(protocol.%s, %s)",
-                        CodegenUtils.getTimeStampFormatName(format), operand));
-                writer.write("if err != nil { return err }");
+                switch (format) {
+                    case EPOCH_SECONDS:
+                        writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
+                        writer.write("f, err := strconv.ParseFloat($L, 64)", operand);
+                        writer.write("if err != nil { return err }");
+                        writer.write("t := smithytime.ParseEpochSeconds(f)");
+                        break;
+                    case HTTP_DATE:
+                        writer.write("t, err := smithytime.ParseHTTPDate($L)", operand);
+                        writer.write("if err != nil { return err }");
+                        break;
+                    case DATE_TIME:
+                        writer.write("t, err := smithytime.ParseDateTime($L)", operand);
+                        writer.write("if err != nil { return err }");
+                        break;
+                    default:
+                        throw new CodegenException("Unexpected timestamp format " + format);
+                }
                 return "t";
             case BYTE:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseInt($L, 0, 8)", operand);
                 writer.write("if err != nil { return err }");
                 return "int8(vv)";
             case SHORT:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseInt($L, 0, 16)", operand);
                 writer.write("if err != nil { return err }");
                 return "int16(vv)";
             case INTEGER:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseInt($L, 0, 32)", operand);
                 writer.write("if err != nil { return err }");
                 return "int32(vv)";
             case LONG:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseInt($L, 0, 64)", operand);
                 writer.write("if err != nil { return err }");
                 return "vv";
             case FLOAT:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseFloat($L, 32)", operand);
                 writer.write("if err != nil { return err }");
                 return "float32(vv)";
             case DOUBLE:
-                writer.addUseImports(GoDependency.STRCONV);
+                writer.addUseImports(SmithyGoDependency.STRCONV.getDependency());
                 writer.write("vv, err := strconv.ParseFloat($L, 64)", operand);
                 writer.write("if err != nil { return err }");
                 return "vv";
             case BIG_INTEGER:
-                writer.addUseImports(GoDependency.BIG);
+                writer.addUseImports(SmithyGoDependency.BIG.getDependency());
                 writer.write("i := big.NewInt(0)");
                 writer.write("bi, ok := i.SetString($L,0)", operand);
                 writer.openBlock("if !ok {", "}", () -> {
@@ -932,7 +948,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 });
                 return "*bi";
             case BIG_DECIMAL:
-                writer.addUseImports(GoDependency.BIG);
+                writer.addUseImports(SmithyGoDependency.BIG.getDependency());
                 writer.write("f := big.NewFloat(0)");
                 writer.write("bd, ok := f.SetString($L,0)", operand);
                 writer.openBlock("if !ok {", "}", () -> {
@@ -943,7 +959,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 });
                 return "*bd";
             case BLOB:
-                writer.addUseImports(GoDependency.BASE64);
+                writer.addUseImports(SmithyGoDependency.BASE64.getDependency());
                 writer.write("b, err := base64.StdEncoding.DecodeString($L)", operand);
                 writer.write("if err != nil { return err }");
                 return "b";
@@ -971,7 +987,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol targetSymbol = symbolProvider.toSymbol(targetShape);
         writer.write("list := make([]$P, 0, 0)", targetSymbol);
 
-        writer.addUseImports(GoDependency.STRINGS);
+        writer.addUseImports(SmithyGoDependency.STRINGS.getDependency());
         writer.openBlock("for _, i := range strings.Split($L[1:len($L)-1], $S) {",
                 "}", operand, operand, ",",
                 () -> {
@@ -1074,7 +1090,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     }
                 });
 
-        for (ShapeId errorShapeId: operation.getErrors()) {
+        for (ShapeId errorShapeId : operation.getErrors()) {
             httpBindingIndex.getResponseBindings(errorShapeId).values()
                     .forEach(binding -> {
                         Shape targetShape = model.expectShape(binding.getMember().getTarget());

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoDependencyTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoDependencyTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.SymbolDependency;
+
+public class GoDependencyTest {
+    @Test
+    public void testStandardLibraryDependency() {
+        GoDependency dependency = GoDependency.builder()
+                .type(GoDependency.Type.STANDARD_LIBRARY)
+                .importPath("net/http")
+                .version("1.14")
+                .build();
+        List<SymbolDependency> symbolDependencies = dependency.getDependencies();
+        assertThat(symbolDependencies.size(), Matchers.equalTo(1));
+        SymbolDependency symbolDependency = symbolDependencies.get(0);
+
+        assertThat(symbolDependency.getDependencyType(), Matchers.equalTo("stdlib"));
+        assertThat(symbolDependency.getPackageName(), Matchers.equalTo(""));
+        assertThat(symbolDependency.getVersion(), Matchers.equalTo("1.14"));
+    }
+
+    @Test
+    public void testSingleDependency() {
+        GoDependency dependency = GoDependency.builder()
+                .type(GoDependency.Type.DEPENDENCY)
+                .sourcePath("github.com/awslabs/smithy-go")
+                .importPath("github.com/awslabs/smithy-go/middleware")
+                .version("1.2.3")
+                .build();
+        List<SymbolDependency> symbolDependencies = dependency.getDependencies();
+        assertThat(symbolDependencies.size(), Matchers.equalTo(1));
+        SymbolDependency symbolDependency = symbolDependencies.get(0);
+
+        assertThat(symbolDependency.getDependencyType(), Matchers.equalTo("dependency"));
+        assertThat(symbolDependency.getPackageName(), Matchers.equalTo("github.com/awslabs/smithy-go"));
+        assertThat(symbolDependency.getVersion(), Matchers.equalTo("1.2.3"));
+    }
+
+    @Test
+    public void testDependencyWithDependencies() {
+        GoDependency dependency = GoDependency.builder()
+                .type(GoDependency.Type.DEPENDENCY)
+                .sourcePath("github.com/aws/aws-sdk-go-v2")
+                .importPath("github.com/aws/aws-sdk-go-v2/aws/middleware")
+                .version("1.2.3")
+                .addDependency(GoDependency.builder()
+                        .type(GoDependency.Type.DEPENDENCY)
+                        .sourcePath("github.com/awslabs/smithy-go")
+                        .importPath("github.com/awslabs/smithy-go/middleware")
+                        .version("3.4.5")
+                        .build())
+                .build();
+        List<SymbolDependency> symbolDependencies = dependency.getDependencies();
+        assertThat(symbolDependencies.size(), Matchers.equalTo(2));
+        assertThat(symbolDependencies, Matchers.containsInAnyOrder(
+                Matchers.equalTo(SymbolDependency.builder()
+                        .dependencyType("dependency")
+                        .packageName("github.com/aws/aws-sdk-go-v2")
+                        .version("1.2.3")
+                        .build()),
+                Matchers.equalTo(SymbolDependency.builder()
+                        .dependencyType("dependency")
+                        .packageName("github.com/awslabs/smithy-go")
+                        .version("3.4.5")
+                        .build())
+        ));
+    }
+
+    @Test
+    public void testDependencyWithNestedDependencies() {
+        GoDependency dependency = GoDependency.builder()
+                .type(GoDependency.Type.DEPENDENCY)
+                .sourcePath("github.com/aws/aws-sdk-go-v2")
+                .importPath("github.com/aws/aws-sdk-go-v2/aws/middleware")
+                .version("1.2.3")
+                .addDependency(GoDependency.builder()
+                        .type(GoDependency.Type.DEPENDENCY)
+                        .sourcePath("github.com/awslabs/smithy-go")
+                        .importPath("github.com/awslabs/smithy-go/middleware")
+                        .version("3.4.5")
+                        .addDependency(GoDependency.builder()
+                                .type(GoDependency.Type.DEPENDENCY)
+                                .sourcePath("github.com/awslabs/smithy-go-extensions")
+                                .importPath("github.com/awslabs/smithy-go-extensions/foobar")
+                                .version("6.7.8")
+                                .addDependency(GoDependency.builder()
+                                        .type(GoDependency.Type.STANDARD_LIBRARY)
+                                        .importPath("net/http")
+                                        .version("1.14")
+                                        .build())
+                                .addDependency(GoDependency.builder()
+                                        .type(GoDependency.Type.STANDARD_LIBRARY)
+                                        .importPath("time")
+                                        .version("1.14")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        List<SymbolDependency> symbolDependencies = dependency.getDependencies();
+        assertThat(symbolDependencies.size(), Matchers.equalTo(4));
+        assertThat(symbolDependencies, Matchers.containsInAnyOrder(
+                Matchers.equalTo(SymbolDependency.builder()
+                        .dependencyType("dependency")
+                        .packageName("github.com/aws/aws-sdk-go-v2")
+                        .version("1.2.3")
+                        .build()),
+                Matchers.equalTo(SymbolDependency.builder()
+                        .dependencyType("dependency")
+                        .packageName("github.com/awslabs/smithy-go")
+                        .version("3.4.5")
+                        .build()),
+                Matchers.equalTo(SymbolDependency.builder()
+                        .dependencyType("dependency")
+                        .packageName("github.com/awslabs/smithy-go-extensions")
+                        .version("6.7.8")
+                        .build()),
+                Matchers.equalTo(SymbolDependency.builder()
+                        .dependencyType("stdlib")
+                        .packageName("")
+                        .version("1.14")
+                        .build())
+        ));
+    }
+}

--- a/time/time.go
+++ b/time/time.go
@@ -19,10 +19,10 @@ func FormatDateTime(value time.Time) string {
 	return value.Format(dateTimeFormat)
 }
 
-// ParseDateTimeFormat parse a string as a date-time
+// ParseDateTime parse a string as a date-time
 //
 // Example: 1985-04-12T23:20:50.52Z
-func ParseDateTimeFormat(value string) (time.Time, error) {
+func ParseDateTime(value string) (time.Time, error) {
 	return time.Parse(dateTimeFormat, value)
 }
 

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -13,7 +13,7 @@ func TestDateTime(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	parseTime, err := ParseDateTimeFormat(dateTime)
+	parseTime, err := ParseDateTime(dateTime)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}


### PR DESCRIPTION
This PR refactors the GoDependency type and constants in order to decouple AWS specific dependencies from the smithy repository.