### PR TITLE
Update Operation to wrap error with smithy operation error

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -95,7 +95,7 @@ final class OperationGenerator implements Runnable {
                     constructHandler();
 
                     writer.write("result, metadata, err := handler.Handle(ctx, params)");
-                    writer.openBlock("if err != nil {", "}", () ->{
+                    writer.openBlock("if err != nil {", "}", () -> {
                         writer.addUseImports(GoDependency.SMITHY);
                         writer.openBlock("return nil, &smithy.OperationError{", "}", () -> {
                             writer.write("ServiceID: c.ServiceID(),");
@@ -111,7 +111,8 @@ final class OperationGenerator implements Runnable {
         // Write out the input and output structures. These are written out here to prevent naming conflicts with other
         // shapes in the model.
         new StructureGenerator(model, symbolProvider, writer, inputShape, inputSymbol)
-                .renderStructure(() -> { }, true);
+                .renderStructure(() -> {
+                }, true);
 
         // The output structure gets a metadata member added.
         Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder(

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -95,7 +95,14 @@ final class OperationGenerator implements Runnable {
                     constructHandler();
 
                     writer.write("result, metadata, err := handler.Handle(ctx, params)");
-                    writer.write("if err != nil { return nil, err }");
+                    writer.openBlock("if err != nil {", "}", () ->{
+                        writer.addUseImports(GoDependency.SMITHY);
+                        writer.openBlock("return nil, &smithy.OperationError{", "}", () -> {
+                            writer.write("ServiceID: c.ServiceID(),");
+                            writer.write("OperationName: \"$T\",", operationSymbol);
+                            writer.write("Err: err,");
+                        });
+                    });
                     writer.write("out := result.($P)", outputSymbol);
                     writer.write("out.ResultMetadata = metadata");
                     writer.write("return out, nil");

--- a/errors.go
+++ b/errors.go
@@ -42,13 +42,13 @@ var _ APIError = (*GenericAPIError)(nil)
 // OperationError decorates an underlying error which occurred while invoking
 // an operation with names of the operation and API.
 type OperationError struct {
-	ServiceName   string
+	ServiceID     string
 	OperationName string
 	Err           error
 }
 
 // Service returns the name of the API service the error occurred with.
-func (e *OperationError) Service() string { return e.ServiceName }
+func (e *OperationError) Service() string { return e.ServiceID }
 
 // Operation returns the name of the API operation the error occurred with.
 func (e *OperationError) Operation() string { return e.OperationName }
@@ -57,7 +57,7 @@ func (e *OperationError) Operation() string { return e.OperationName }
 func (e *OperationError) Unwrap() error { return e.Err }
 
 func (e *OperationError) Error() string {
-	return fmt.Sprintf("operation error %s: %s, %v", e.ServiceName, e.OperationName, e.Err)
+	return fmt.Sprintf("operation error %s: %s, %v", e.ServiceID, e.OperationName, e.Err)
 }
 
 // DeserializationError provides a wrapper for and error that occurs during


### PR DESCRIPTION
Updates the API client's operation methods to wrap the middleware stack returned error with the smithy OperationError value annotating service and operation the error came from.

```go
	handler := middleware.DecorateHandler(smithyhttp.NewClientHandler(options.HTTPClient), stack)
	result, metadata, err := handler.Handle(ctx, params)
	if err != nil {
		return nil, &smithy.OperationError{
			ServiceID:     c.ServiceID(),
			OperationName: "AllQueryStringTypes",
			Err:           err,
		}
	}
	out := result.(*AllQueryStringTypesOutput)
	out.ResultMetadata = metadata
	return out, nil
```