### PR TITLE
Add config field interface to RuntimeClientPlugin

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -16,8 +16,11 @@
 package software.amazon.smithy.go.codegen;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.integration.ConfigField;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
@@ -125,12 +128,25 @@ final class ServiceGenerator implements Runnable {
             );
             writer.write("APIOptions []$L", API_OPTIONS_FUNC_NAME).write("");
 
-            for (GoIntegration integration : integrations) {
-                integration.addConfigFields(settings, model, symbolProvider, writer);
+            // Add config fields to the options struct.
+            for (ConfigField configField : getAllConfigFields()) {
+                configField.getDocumentation().ifPresent(writer::writeDocs);
+                writer.write("$L $P", configField.getName(), configField.getType());
+                writer.write("");
             }
 
             generateApplicationProtocolConfig();
         }).write("");
+
+        // Add config field getters, which are useful for creating any necessary interfaces to accept
+        // some subset of the config.
+        for (ConfigField configField : getAllConfigFields()) {
+            writer.openBlock("func (o $L) Get$L() $P {", "}",
+                    CONFIG_NAME, configField.getName(), configField.getType(), () -> {
+                writer.write("return o.$L", configField.getName());
+            });
+            writer.write("");
+        }
 
         generateApplicationProtocolTypes();
 
@@ -141,6 +157,17 @@ final class ServiceGenerator implements Runnable {
             writer.write("copy(to.APIOptions, o.APIOptions)");
             writer.write("return to");
         });
+    }
+
+    private Set<ConfigField> getAllConfigFields() {
+        Set<ConfigField> configFields = new TreeSet<>();
+        for (RuntimeClientPlugin runtimeClientPlugin : runtimePlugins) {
+            if (!runtimeClientPlugin.matchesService(model, service)) {
+                continue;
+            }
+            configFields.addAll(runtimeClientPlugin.getConfigFields());
+        }
+        return configFields;
     }
 
     private void generateApplicationProtocolConfig() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -15,9 +15,10 @@
 
 package software.amazon.smithy.go.codegen;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.integration.ConfigField;
@@ -159,15 +160,19 @@ final class ServiceGenerator implements Runnable {
         });
     }
 
-    private Set<ConfigField> getAllConfigFields() {
-        Set<ConfigField> configFields = new TreeSet<>();
+    private List<ConfigField> getAllConfigFields() {
+        List<ConfigField> configFields = new ArrayList<>();
         for (RuntimeClientPlugin runtimeClientPlugin : runtimePlugins) {
             if (!runtimeClientPlugin.matchesService(model, service)) {
                 continue;
             }
             configFields.addAll(runtimeClientPlugin.getConfigFields());
         }
-        return configFields;
+
+        return configFields.stream()
+                .distinct()
+                .sorted(Comparator.comparing(ConfigField::getName))
+                .collect(Collectors.toList());
     }
 
     private void generateApplicationProtocolConfig() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Objects;
+import java.util.Optional;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Represents a config field on a client config struct.
+ */
+public class ConfigField implements ToSmithyBuilder<ConfigField>, Comparable<ConfigField> {
+    private final String name;
+    private final Symbol type;
+    private final String documentation;
+
+    public ConfigField(Builder builder) {
+        this.name = Objects.requireNonNull(builder.name);
+        this.type = Objects.requireNonNull(builder.type);
+        this.documentation = builder.documentation;
+    }
+
+    /**
+     * @return Returns the name of the config field.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return Returns the type Symbol for the field.
+     */
+    public Symbol getType() {
+        return type;
+    }
+
+    /**
+     * @return Gets the optional documentation for the field.
+     */
+    public Optional<String> getDocumentation() {
+        return Optional.ofNullable(documentation);
+    }
+
+    @Override
+    public SmithyBuilder<ConfigField> toBuilder() {
+        return builder().type(type).name(name).documentation(documentation);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public int compareTo(ConfigField o) {
+        return this.getName().compareTo(o.getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConfigField that = (ConfigField) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    /**
+     * Builds a ConfigField.
+     */
+    public static class Builder implements SmithyBuilder<ConfigField> {
+        private String name;
+        private Symbol type;
+        private String documentation;
+
+        @Override
+        public ConfigField build() {
+            return new ConfigField(this);
+        }
+
+        /**
+         * Set the name of the config field.
+         *
+         * @param name the name of the config field.
+         * @return Returns the builder.
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the type of the config field.
+         *
+         * @param type A Symbol representing the type of the config field.
+         * @return Returns the builder.
+         */
+        public Builder type(Symbol type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets the documentation for the config field.
+         *
+         * @param documentation The documentation for the config field.
+         * @return Returns the builder.
+         */
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
+            return this;
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
@@ -24,7 +24,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 /**
  * Represents a config field on a client config struct.
  */
-public class ConfigField implements ToSmithyBuilder<ConfigField>, Comparable<ConfigField> {
+public class ConfigField implements ToSmithyBuilder<ConfigField> {
     private final String name;
     private final Symbol type;
     private final String documentation;
@@ -66,11 +66,6 @@ public class ConfigField implements ToSmithyBuilder<ConfigField>, Comparable<Con
     }
 
     @Override
-    public int compareTo(ConfigField o) {
-        return this.getName().compareTo(o.getName());
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -79,12 +74,14 @@ public class ConfigField implements ToSmithyBuilder<ConfigField>, Comparable<Con
             return false;
         }
         ConfigField that = (ConfigField) o;
-        return Objects.equals(name, that.name);
+        return Objects.equals(getName(), that.getName())
+                && Objects.equals(getType(), that.getType())
+                && Objects.equals(getDocumentation(), that.getDocumentation());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return Objects.hash(getName(), getType(), getDocumentation());
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -18,11 +18,7 @@ package software.amazon.smithy.go.codegen.integration;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
-
-import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
-import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
@@ -163,50 +159,5 @@ public interface GoIntegration {
      */
     default List<RuntimeClientPlugin> getClientPlugins() {
         return Collections.emptyList();
-    }
-
-    /**
-     * Adds additional client config fields.
-     *
-     * <p>Implementations of this method are expected to add fields to the
-     * "ClientOptions" struct of a generated client. Implementations are
-     * expected to write field names and their type signatures. Any number
-     * of fields can be added, and any {@link Symbol} or {@link SymbolReference}
-     * objects that are written to the writer are automatically imported, and
-     * any of their contained {@link SymbolDependency} values are automatically
-     * added to the generated {@code go.mod} file.
-     *
-     * <p>For example, the following code adds two fields to a client:
-     *
-     * <pre>
-     * {@code
-     * public final class MyIntegration implements GoIntegration {
-     *     public void addConfigFields(
-     *             GoSettings settings,
-     *             Model model,
-     *             SymbolProvider symbolProvider,
-     *             GoWriter writer
-     *     ) {
-     *         writer.writeDocs("The docs for foo...");
-     *         writer.write("Foo *string");
-     *
-     *         writer.writeDocs("The docs for bar...");
-     *         writer.write("Bar string;");
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param settings Settings used to generate.
-     * @param model Model to generate from.
-     * @param symbolProvider Symbol provider used for codegen.
-     * @param writer Go writer to write to.
-     */
-    default void addConfigFields(
-            GoSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            GoWriter writer
-    ) {
-        // pass
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BiPredicate;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
@@ -40,11 +42,13 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final Symbol resolveFunction;
     private final BiPredicate<Model, ServiceShape> servicePredicate;
     private final OperationPredicate operationPredicate;
+    private final Set<ConfigField> configFields;
 
     private RuntimeClientPlugin(Builder builder) {
         resolveFunction = builder.resolveFunction;
         operationPredicate = builder.operationPredicate;
         servicePredicate = builder.servicePredicate;
+        configFields = builder.configFields;
     }
 
     @FunctionalInterface
@@ -109,6 +113,27 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         return operationPredicate.test(model, service, operation);
     }
 
+    /**
+     * Gets the config fields that will be added to the client config by this plugin.
+     *
+     * <p>Each config field will be added to the client's Config object and will
+     * result in a corresponding getter method being added to the config. E.g.:
+     *
+     * type ClientOptions struct {
+     *     // My docs.
+     *     MyField string
+     * }
+     *
+     * func (o ClientOptions) GetMyField() string {
+     *     return o.MyField
+     * }
+     *
+     * @return Returns the config fields to add to the client config.
+     */
+    public Set<ConfigField> getConfigFields() {
+        return configFields;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -128,6 +153,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private Symbol resolveFunction;
         private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
         private OperationPredicate operationPredicate = (model, service, operation) -> false;
+        private Set<ConfigField> configFields = new TreeSet<>();
 
         @Override
         public RuntimeClientPlugin build() {
@@ -202,6 +228,52 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         public Builder servicePredicate(BiPredicate<Model, ServiceShape> servicePredicate) {
             this.servicePredicate = Objects.requireNonNull(servicePredicate);
             operationPredicate = (model, service, operation) -> false;
+            return this;
+        }
+
+        /**
+         * Sets the config fields that will be added to the client config by this plugin.
+         *
+         * <p>Each config field will be added to the client's Config object and will
+         * result in a corresponding getter method being added to the config. E.g.:
+         *
+         * type ClientOptions struct {
+         *     // My docs.
+         *     MyField string
+         * }
+         *
+         * func (o ClientOptions) GetMyField() string {
+         *     return o.MyField
+         * }
+         *
+         * @param configFields The config fields to add to the client config.
+         * @return Returns the builder.
+         */
+        public Builder configFields(Collection<ConfigField> configFields) {
+            this.configFields = new TreeSet<>(configFields);
+            return this;
+        }
+
+        /**
+         * Adds a config field that will be added to the client config by this plugin.
+         *
+         * <p>Each config field will be added to the client's Config object and will
+         * result in a corresponding getter method being added to the config. E.g.:
+         *
+         * type ClientOptions struct {
+         *     // My docs.
+         *     MyField string
+         * }
+         *
+         * func (o ClientOptions) GetMyField() string {
+         *     return o.MyField
+         * }
+         *
+         * @param configField The config field to add to the client config.
+         * @return Returns the builder.
+         */
+        public Builder addConfigField(ConfigField configField) {
+            this.configFields.add(configField);
             return this;
         }
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -16,10 +16,10 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.BiPredicate;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
@@ -153,7 +153,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private Symbol resolveFunction;
         private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
         private OperationPredicate operationPredicate = (model, service, operation) -> false;
-        private Set<ConfigField> configFields = new TreeSet<>();
+        private Set<ConfigField> configFields = new HashSet<>();
 
         @Override
         public RuntimeClientPlugin build() {
@@ -250,7 +250,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * @return Returns the builder.
          */
         public Builder configFields(Collection<ConfigField> configFields) {
-            this.configFields = new TreeSet<>(configFields);
+            this.configFields = new HashSet<>(configFields);
             return this;
         }
 


### PR DESCRIPTION
*Description of changes:*

This changes the way that client config options are added. Now a `RuntimeClientPlugin` can register a number of fields to add to a config. Each option will be added to that config, and a getter will be generated to enable creating interfaces.

For example:

```java
@Override
public List<RuntimeClientPlugin> getClientPlugins() {
    return ListUtils.of(RuntimeClientPlugin.builder()
            .addConfigField(ConfigField.builder()
                    .name("MyConfig")
                    .type(SymbolUtils.createPointableSymbolBuilder("int64")
                            .putProperty(SymbolUtils.GO_UNIVERSE_TYPE, true)
                            .build())
                    .documentation("My config")
                    .build())
            .build());
}
```

```go
type Options struct {
	// Set of options to modify how an operation is invoked. These apply to all
	// operations invoked for this client. Use functional options on operation call to
	// modify this list for per operation behavior.
	APIOptions []APIOptionFunc

	// My config
	MyConfig *int64
	
	// The HTTP client to invoke API calls with. Defaults to client's default HTTP
	// implementation if nil.
	HTTPClient HTTPClient
}

func (o Options) GetMyConfig() *int64 {
	return o.MyConfig
}
```

~~EDIT: this was supposed to be a draft - there are still a few touch ups before this could be merged, e.g. removing the writer from GoIntegration and adding docs to ConfigField~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
