### PR TITLE
Add Go build to finalize codegen step, and fixup error generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 sudo: true
 dist: bionic
-install: /bin/true
-before_script:
+
+install:
     - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.14.x bash)"
     - echo `go env`
     - echo `which go`

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 sudo: true
 dist: bionic
 install: /bin/true
+before_script:
+    - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.14.x bash)"
+    - echo `go env`
+    - echo `which go`
+
 script: cd codegen && ./gradlew clean build -Plog-tests
 
 matrix:

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -202,6 +202,64 @@ public final class CodegenUtils {
     }
 
     /**
+     * Gets a value version of the operate based on the shape type. Returns a string with dereferencing the provided
+     * operand value if needed. Shapes like Structure, maps, and slices are not dereferenced.
+     *
+     * @param writer  The writer dependencies will be added to, if needed.
+     * @param shape   The shape whose value needs to be assigned.
+     * @param operand The Operand is the value to be assigned to the symbol shape.
+     * @return The Operand, along with pointer reference if applicable
+     */
+    public static String operandValueIfScalar(GoWriter writer, Shape shape, String operand) {
+        String prefix = "";
+        String suffix = ")";
+
+        switch (shape.getType()) {
+            case STRING:
+                if (shape.hasTrait(EnumTrait.class)) {
+                    return operand;
+                }
+
+                prefix = "ptr.ToString(";
+                break;
+
+            case BOOLEAN:
+                prefix = "ptr.ToBool(";
+                break;
+
+            case BYTE:
+                prefix = "ptr.ToInt8(";
+                break;
+            case SHORT:
+                prefix = "ptr.ToInt16(";
+                break;
+            case INTEGER:
+                prefix = "ptr.ToInt32(";
+                break;
+            case LONG:
+                prefix = "ptr.ToInt64(";
+                break;
+
+            case FLOAT:
+                prefix = "ptr.ToFloat32(";
+                break;
+            case DOUBLE:
+                prefix = "ptr.ToFloat64(";
+                break;
+
+            case TIMESTAMP:
+                prefix = "ptr.ToTime(";
+                break;
+
+            default:
+                return operand;
+        }
+
+        writer.addUseImports(SmithyGoDependency.SMITHY_PTR);
+        return prefix + operand + suffix;
+    }
+
+    /**
      * Returns whether the shape should be passed by value in Go.
      *
      * @param shape the shape

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -199,6 +199,10 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         LOGGER.fine("Running go fmt");
         CodegenUtils.runCommand("go fmt", fileManifest.getBaseDir());
+
+        // TODO this should be moved to a smithy gradle task
+        LOGGER.fine("Running go build");
+        CodegenUtils.runCommand("go test -run NONE ./...", fileManifest.getBaseDir());
     }
 
     @Override


### PR DESCRIPTION
Adds go build to the set of commands run after the code generation completes. This ensures that the generated code compiles. Both test and regular code.

Fixes up error shape generation so that exception getters methods return the expected type and use the smithy-go/ptr pkg for converting scalar pointers to values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
