### PR TITLE
Refactors middleware addition to stack

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -76,10 +76,6 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 .forEach(integration -> {
                     LOGGER.info(() -> "Adding GoIntegration: " + integration.getClass().getName());
                     integrations.add(integration);
-                    integration.getClientPlugins().forEach(runtimePlugin -> {
-                        LOGGER.info(() -> "Adding Go runtime plugin: " + runtimePlugin);
-                        runtimePlugins.add(runtimePlugin);
-                    });
                 });
         integrations.sort(Comparator.comparingInt(GoIntegration::getOrder));
 
@@ -96,6 +92,20 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         resolvedModel = AddOperationShapes.execute(resolvedModel, settings.getService());
 
         model = resolvedModel;
+
+        // process final model
+        integrations.forEach(integration -> {
+            integration.processFinalizeModel(settings, model);
+        });
+
+        // fetch runtime plugins
+        integrations.forEach(integration -> {
+            integration.getClientPlugins().forEach(runtimePlugin -> {
+                LOGGER.info(() -> "Adding Go runtime plugin: " + runtimePlugin);
+                runtimePlugins.add(runtimePlugin);
+            });
+        });
+
         modelWithoutTraitShapes = ModelTransformer.create().getModelWithoutTraitShapes(model);
 
         service = settings.getService(model);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -164,6 +164,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         for (GoIntegration integration : integrations) {
             integration.writeAdditionalFiles(settings, model, symbolProvider, writers::useFileWriter);
+            integration.writeAdditionalFiles(settings, model, symbolProvider, writers);
         }
 
         if (protocolGenerator != null) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -95,7 +95,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         // process final model
         integrations.forEach(integration -> {
-            integration.processFinalizeModel(settings, model);
+            integration.processFinalizedModel(settings, model);
         });
 
         // fetch runtime plugins

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -15,10 +15,7 @@
 
 package software.amazon.smithy.go.codegen;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -192,12 +189,9 @@ final class OperationGenerator implements Runnable {
                 MiddlewareRegistrar middlewareRegistrar = runtimeClientPlugin.registerMiddleware().get();
                 writer.writeInline("$T(stack", middlewareRegistrar.getResolvedFunction());
 
-                Collection<Symbol> functionArguments = middlewareRegistrar.getFunctionArguments();
-                if (functionArguments != null) {
-                    Set<Symbol> args = new HashSet<>(functionArguments);
-                    for (Symbol arg: args) {
-                        writer.writeInline(", $P", arg);
-                    }
+                Symbol functionArgument = middlewareRegistrar.getFunctionArgument();
+                if (functionArgument != null) {
+                        writer.writeInline(", $P", functionArgument);
                 }
                 writer.write(")");
             }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -153,6 +153,17 @@ public interface GoIntegration {
     }
 
     /**
+     * Finalizes the model. This plugin can be used to add RuntimeClientPlugins
+     * to the integration's list of plugin.
+     *
+     * @param settings Settings used to generate.
+     * @param model Model to generate from.
+     */
+    default void processFinalizeModel(GoSettings settings, Model model) {
+        // pass
+    }
+
+    /**
      * Gets a list of plugins to apply to the generated client.
      *
      * @return Returns the list of RuntimePlugins to apply to the client.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
@@ -122,6 +123,23 @@ public interface GoIntegration {
             Model model,
             SymbolProvider symbolProvider,
             TriConsumer<String, String, Consumer<GoWriter>> writerFactory
+    ) {
+        // pass
+    }
+
+    /**
+     * Writes additional files.
+     *
+     * @param settings Settings used to generate.
+     * @param model Model to generate from.
+     * @param symbolProvider Symbol provider used for codegen.
+     * @param goDelegator GoDelegator used to manage writer for the file.
+     */
+    default void writeAdditionalFiles(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoDelegator goDelegator
     ) {
         // pass
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -153,13 +153,14 @@ public interface GoIntegration {
     }
 
     /**
-     * Finalizes the model. This plugin can be used to add RuntimeClientPlugins
+     * Processes the finalized model before runtime plugins are consumed and
+     * code generation starts. This plugin can be used to add RuntimeClientPlugins
      * to the integration's list of plugin.
      *
      * @param settings Settings used to generate.
      * @param model Model to generate from.
      */
-    default void processFinalizeModel(GoSettings settings, Model model) {
+    default void processFinalizedModel(GoSettings settings, Model model) {
         // pass
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -15,10 +15,8 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -153,9 +151,6 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
-        Set<Symbol> functionArgs = new HashSet<>();
-        functionArgs.add(SymbolUtils.createValueSymbolBuilder("options").build());
-
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .operationPredicate((model, service, operation) -> {
@@ -177,10 +172,9 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
                         })
                         .registerMiddleware(
                                 MiddlewareRegistrar.builder()
-                                        .resolvedFunction(
-                                                SymbolUtils.createValueSymbolBuilder(
-                                                        "addIdempotencyTokenMiddleware").build())
-                                        .functionArguments(functionArgs)
+                                        .resolvedFunction(SymbolUtils.createValueSymbolBuilder(
+                                                "addIdempotencyTokenMiddleware").build())
+                                        .functionArgument(SymbolUtils.createValueSymbolBuilder("options").build())
                                         .build()
                         )
                         .build()

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -79,7 +79,7 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
     }
 
     @Override
-    public void processFinalizeModel(GoSettings settings, Model model) {
+    public void processFinalizedModel(GoSettings settings, Model model) {
         ServiceShape service = settings.getService(model);
         for (ShapeId operationId : service.getAllOperations()) {
             OperationShape operation = model.expectShape(operationId, OperationShape.class);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
@@ -15,39 +15,59 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Objects;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
-
 public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar> {
     private final Symbol resolvedFunction;
-    private final Symbol functionArgument;
+    private final Collection<Symbol> functionArguments;
+    private final String inlineRegisterMiddlewareStatement;
+    private final Symbol inlineRegisterMiddlewarePosition;
 
     public MiddlewareRegistrar(Builder builder) {
         this.resolvedFunction = builder.resolvedFunction;
-        this.functionArgument = builder.functionArgument;
+        this.functionArguments = builder.functionArguments;
+        this.inlineRegisterMiddlewareStatement = builder.inlineRegisterMiddlewareStatement;
+        this.inlineRegisterMiddlewarePosition = builder.inlineRegisterMiddlewarePosition;
     }
 
     /**
-     * @return Returns symbol that resolves to a function.
+     * @return symbol that resolves to a function.
      */
     public Symbol getResolvedFunction() {
         return resolvedFunction;
     }
 
     /**
-     * @return Returns a symbol denoting the argument of the resolved function.
+     * @return collection of symbols denoting the arguments of the resolved function.
      */
-    public Symbol getFunctionArgument() {
-        return functionArgument;
+    public Collection<Symbol> getFunctionArguments() {
+        return functionArguments;
+    }
+
+    /**
+     * @return string denoting inline middleware registration in the stack
+     */
+    public String getInlineRegisterMiddlewareStatement() {
+        return inlineRegisterMiddlewareStatement;
+    }
+
+    /**
+     * @return symbol used to define the middleware position in the stack
+     */
+    public Symbol getInlineRegisterMiddlewarePosition() {
+        return inlineRegisterMiddlewarePosition;
     }
 
     @Override
     public SmithyBuilder<MiddlewareRegistrar> toBuilder() {
-        return builder().functionArgument(functionArgument).resolvedFunction(resolvedFunction);
+        return builder().functionArguments(functionArguments).resolvedFunction(resolvedFunction);
     }
 
     public static MiddlewareRegistrar.Builder builder() {
@@ -64,12 +84,12 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
         }
         MiddlewareRegistrar that = (MiddlewareRegistrar) o;
         return Objects.equals(getResolvedFunction(), that.getResolvedFunction())
-                && Objects.equals(getFunctionArgument(), that.getFunctionArgument());
+                && Objects.equals(getFunctionArguments(), that.getFunctionArguments());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getResolvedFunction(), getFunctionArgument());
+        return Objects.hash(getResolvedFunction(), getFunctionArguments());
     }
 
 
@@ -78,7 +98,9 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
      */
     public static class Builder implements SmithyBuilder<MiddlewareRegistrar> {
         private Symbol resolvedFunction;
-        private Symbol functionArgument;
+        private Collection<Symbol> functionArguments;
+        private String inlineRegisterMiddlewareStatement;
+        private Symbol inlineRegisterMiddlewarePosition;
 
         @Override
         public MiddlewareRegistrar build() {
@@ -97,13 +119,14 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
         }
 
         /**
-         * Sets the function Argument for the MiddlewareRegistrar function.
+         * Sets the function Arguments for the MiddlewareRegistrar function.
          *
-         * @param functionArgument A Symbol representing the argument to the middleware register function.
+         * @param functionArguments A collection of symbols representing the arguments
+         *                          to the middleware register function.
          * @return Returns the builder.
          */
-        public Builder functionArgument(Symbol functionArgument) {
-            this.functionArgument = functionArgument;
+        public Builder functionArguments(Collection<Symbol> functionArguments) {
+            this.functionArguments = new ArrayList<>(functionArguments);
             return this;
         }
 
@@ -112,9 +135,72 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
          *
          * @return Returns the builder.
          */
-        public Builder setClientOptionsAsFunctionArgument() {
-            this.functionArgument = SymbolUtils.createValueSymbolBuilder("options").build();
+        public Builder useClientOptions() {
+            Collection<Symbol> args = new ArrayList<>();
+            args.add(SymbolUtils.createValueSymbolBuilder("options").build());
+            this.functionArguments = args;
             return this;
+        }
+
+        /**
+         * Adds a middleware to the middleware stack at relative position of After.
+         * @param stackStep Stack step.
+         * @return Returns the Builder.
+         */
+        public Builder registerAfter(StackStep stackStep) {
+            this.inlineRegisterMiddlewareStatement = String.format("%s.Add(", stackStep);
+            this.inlineRegisterMiddlewarePosition = getMiddlewareAfterPositionSymbol();
+            return this;
+        }
+
+        /**
+         * Adds the middleware to the middleware stack at relative position of Before.
+         * @param stackStep Stack step at which the middleware is to be register.
+         * @return Returns the Builder.
+         */
+        public Builder registerBefore(StackStep stackStep) {
+            this.inlineRegisterMiddlewareStatement = String.format("%s.Add(", stackStep);
+            this.inlineRegisterMiddlewarePosition = getMiddlewareBeforePositionSymbol();
+            return this;
+        }
+
+        private Symbol getMiddlewareAfterPositionSymbol() {
+            return SymbolUtils.createValueSymbolBuilder("After",
+                    SmithyGoDependency.SMITHY_MIDDLEWARE).build();
+        }
+
+        private Symbol getMiddlewareBeforePositionSymbol() {
+            return SymbolUtils.createValueSymbolBuilder("Before",
+                    SmithyGoDependency.SMITHY_MIDDLEWARE).build();
+        }
+    }
+
+    /**
+     * Represents the middleware stack step.
+     */
+    public enum StackStep {
+        INITIALIZE,
+        BUILD,
+        SERIALIZE,
+        DESERIALIZE,
+        FINALIZE;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case INITIALIZE:
+                    return "Initialize";
+                case BUILD:
+                    return "Build";
+                case SERIALIZE:
+                    return "Serialize";
+                case DESERIALIZE:
+                    return "Deserialize";
+                case FINALIZE:
+                    return "Finalize";
+                default:
+                    return "Unknown";
+            }
         }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
@@ -15,8 +15,6 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Objects;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -25,11 +23,11 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 
 public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar> {
     private final Symbol resolvedFunction;
-    private final Collection<Symbol> functionArguments;
+    private final Symbol functionArgument;
 
     public MiddlewareRegistrar(Builder builder) {
         this.resolvedFunction = builder.resolvedFunction;
-        this.functionArguments = builder.functionArguments;
+        this.functionArgument = builder.functionArgument;
     }
 
     /**
@@ -40,15 +38,15 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
     }
 
     /**
-     * @return Returns a Collection of symbols denoting the arguments of the resolved function.
+     * @return Returns a symbol denoting the argument of the resolved function.
      */
-    public Collection<Symbol> getFunctionArguments() {
-        return functionArguments;
+    public Symbol getFunctionArgument() {
+        return functionArgument;
     }
 
     @Override
     public SmithyBuilder<MiddlewareRegistrar> toBuilder() {
-        return builder().functionArguments(functionArguments).resolvedFunction(resolvedFunction);
+        return builder().functionArgument(functionArgument).resolvedFunction(resolvedFunction);
     }
 
     public static MiddlewareRegistrar.Builder builder() {
@@ -65,12 +63,12 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
         }
         MiddlewareRegistrar that = (MiddlewareRegistrar) o;
         return Objects.equals(getResolvedFunction(), that.getResolvedFunction())
-                && Objects.equals(getFunctionArguments(), that.getFunctionArguments());
+                && Objects.equals(getFunctionArgument(), that.getFunctionArgument());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getResolvedFunction(), getFunctionArguments());
+        return Objects.hash(getResolvedFunction(), getFunctionArgument());
     }
 
 
@@ -79,7 +77,7 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
      */
     public static class Builder implements SmithyBuilder<MiddlewareRegistrar> {
         private Symbol resolvedFunction;
-        private Collection<Symbol> functionArguments;
+        private Symbol functionArgument;
 
         @Override
         public MiddlewareRegistrar build() {
@@ -98,13 +96,13 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
         }
 
         /**
-         * Sets the function Arguments for the MiddlewareRegistrar function.
+         * Sets the function Argument for the MiddlewareRegistrar function.
          *
-         * @param functionArguments A Symbol representing the type of the config field.
+         * @param functionArgument A Symbol representing the argument to the middleware register function.
          * @return Returns the builder.
          */
-        public Builder functionArguments(Collection<Symbol> functionArguments) {
-            this.functionArguments = new HashSet<>(functionArguments);
+        public Builder functionArgument(Symbol functionArgument) {
+            this.functionArgument = functionArgument;
             return this;
         }
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+
+public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar> {
+    private final Symbol resolvedFunction;
+    private final Collection<Symbol> functionArguments;
+
+    public MiddlewareRegistrar(Builder builder) {
+        this.resolvedFunction = builder.resolvedFunction;
+        this.functionArguments = builder.functionArguments;
+    }
+
+    /**
+     * @return Returns symbol that resolves to a function.
+     */
+    public Symbol getResolvedFunction() {
+        return resolvedFunction;
+    }
+
+    /**
+     * @return Returns a Collection of symbols denoting the arguments of the resolved function.
+     */
+    public Collection<Symbol> getFunctionArguments() {
+        return functionArguments;
+    }
+
+    @Override
+    public SmithyBuilder<MiddlewareRegistrar> toBuilder() {
+        return builder().functionArguments(functionArguments).resolvedFunction(resolvedFunction);
+    }
+
+    public static MiddlewareRegistrar.Builder builder() {
+        return new MiddlewareRegistrar.Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MiddlewareRegistrar that = (MiddlewareRegistrar) o;
+        return Objects.equals(getResolvedFunction(), that.getResolvedFunction())
+                && Objects.equals(getFunctionArguments(), that.getFunctionArguments());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getResolvedFunction(), getFunctionArguments());
+    }
+
+
+    /**
+     * Builds a MiddlewareRegistrar.
+     */
+    public static class Builder implements SmithyBuilder<MiddlewareRegistrar> {
+        private Symbol resolvedFunction;
+        private Collection<Symbol> functionArguments;
+
+        @Override
+        public MiddlewareRegistrar build() {
+            return new MiddlewareRegistrar(this);
+        }
+
+        /**
+         * Set the name of the MiddlewareRegistrar function.
+         *
+         * @param resolvedFunction a symbol that resolves to the function .
+         * @return Returns the builder.
+         */
+        public Builder resolvedFunction(Symbol resolvedFunction) {
+            this.resolvedFunction = resolvedFunction;
+            return this;
+        }
+
+        /**
+         * Sets the function Arguments for the MiddlewareRegistrar function.
+         *
+         * @param functionArguments A Symbol representing the type of the config field.
+         * @return Returns the builder.
+         */
+        public Builder functionArguments(Collection<Symbol> functionArguments) {
+            this.functionArguments = new HashSet<>(functionArguments);
+            return this;
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/MiddlewareRegistrar.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.go.codegen.integration;
 
 import java.util.Objects;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -103,6 +104,16 @@ public class MiddlewareRegistrar implements ToSmithyBuilder<MiddlewareRegistrar>
          */
         public Builder functionArgument(Symbol functionArgument) {
             this.functionArgument = functionArgument;
+            return this;
+        }
+
+        /**
+         * Sets symbol that resolves to options as an argument for the resolved function.
+         *
+         * @return Returns the builder.
+         */
+        public Builder setClientOptionsAsFunctionArgument() {
+            this.functionArgument = SymbolUtils.createValueSymbolBuilder("options").build();
             return this;
         }
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -38,13 +38,11 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * build-time.
  */
 public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientPlugin> {
-
     private final Symbol resolveFunction;
     private final BiPredicate<Model, ServiceShape> servicePredicate;
     private final OperationPredicate operationPredicate;
     private final Set<ConfigField> configFields;
     private final MiddlewareRegistrar registerMiddleware;
-
 
     private RuntimeClientPlugin(Builder builder) {
         resolveFunction = builder.resolveFunction;

--- a/transport/http/retry.go
+++ b/transport/http/retry.go
@@ -1,5 +1,0 @@
-package http
-
-type Retryer interface {
-	// TODO: Fill this interface
-}

--- a/transport/http/retry.go
+++ b/transport/http/retry.go
@@ -1,0 +1,5 @@
+package http
+
+type Retryer interface {
+	// TODO: Fill this interface
+}


### PR DESCRIPTION
*Description of changes:*
* Adds a runtime client plugin to register middlewares on stack.
* Middlewares can now be registered both inline or using middleware helper functions.
* Updates IdempotencyToken middleware generation logic to use a value provider interface. 
* Updates to work with new client option getters
* Related to aws/aws-sdk-go-v2#596

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
