### PR TITLE
Support HTTP RPC protocols

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeDeserVisitor.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+
+/**
+ * Visitor to generate deserialization functions for shapes in protocol document bodies.
+ *
+ * Visitor methods for aggregate types are final and will generate functions that dispatch
+ * their loading from the body to the matching abstract method.
+ *
+ * Visitor methods for all other types will default to not generating deserialization
+ * functions. This may be overwritten by downstream implementations if the protocol requires
+ * more complex deserialization strategies for those types.
+ *
+ * The standard implementation is as follows; no assumptions are made about the protocol
+ * being generated for.
+ *
+ * <ul>
+ *   <li>Service, Operation, Resource: no function generated. <b>Not overridable.</b></li>
+ *   <li>Document, List, Map, Set, Structure, Union: generates a deserialization function.
+ *     <b>Not overridable.</b></li>
+ *   <li>All other types: no function generated. <b>May be overridden.</b></li>
+ * </ul>
+ */
+public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Void> {
+    private final GenerationContext context;
+
+    public DocumentShapeDeserVisitor(GenerationContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
+    }
+
+    @Override
+    protected Void getDefault(Shape shape) {
+        return null;
+    }
+
+    /**
+     * Writes the code needed to deserialize a collection in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the CollectionShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The collection shape being generated.
+     */
+    protected abstract void deserializeCollection(GenerationContext context, CollectionShape shape);
+
+    /**
+     * Writes the code needed to deserialize a document shape in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the DocumentShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The document shape being generated.
+     */
+    protected abstract void deserializeDocument(GenerationContext context, DocumentShape shape);
+
+    /**
+     * Writes the code needed to deserialize a map in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the MapShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The map shape being generated.
+     */
+    protected abstract void deserializeMap(GenerationContext context, MapShape shape);
+
+    /**
+     * Writes the code needed to deserialize a structure in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the StructureShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The structure shape being generated.
+     */
+    protected abstract void deserializeStructure(GenerationContext context, StructureShape shape);
+
+    /**
+     * Writes the code needed to deserialize a union in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the UnionShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The union shape being generated.
+     */
+    protected abstract void deserializeUnion(GenerationContext context, UnionShape shape);
+
+    /**
+     * Generates a function for deserializing the output shape, dispatching body handling
+     * to the supplied function.
+     *
+     * @param shape The shape to generate a deserializer for.
+     * @param functionBody An implementation that will generate a function body to
+     *                     deserialize the shape.
+     */
+    protected final void generateDeserFunction(
+            Shape shape,
+            BiConsumer<GenerationContext, Shape> functionBody
+    ) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        GoWriter writer = context.getWriter();
+
+        Symbol symbol = symbolProvider.toSymbol(shape);
+        String functionName = ProtocolGenerator.getDocumentDeserializerFunctionName(shape, context.getProtocolName());
+
+        String additionalArguments = getAdditionalArguments().entrySet().stream()
+                .map(entry -> String.format(", %s %s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining());
+
+        writer.openBlock("func $L(v *$P$L) error {", "}", functionName, symbol, additionalArguments, () -> {
+            writer.addUseImports(SmithyGoDependency.FMT);
+            writer.openBlock("if v == nil {", "}", () -> {
+                writer.write("return fmt.Errorf(\"unexpected nil of type %T\", v)");
+            });
+            functionBody.accept(context, shape);
+        }).write("");
+    }
+
+    /**
+     * Gets any additional arguments needed for every deserializer function.
+     *
+     * @return a map of argument name to argument type.
+     */
+    protected Map<String, String> getAdditionalArguments() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public final Void operationShape(OperationShape shape) {
+        throw new CodegenException("Operation shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void resourceShape(ResourceShape shape) {
+        throw new CodegenException("Resource shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void serviceShape(ServiceShape shape) {
+        throw new CodegenException("Service shapes cannot be bound to documents.");
+    }
+
+    /**
+     * Dispatches to create the body of document shape deserilization functions.
+     *
+     * @param shape The document shape to generate deserialization for.
+     * @return null
+     */
+    @Override
+    public final Void documentShape(DocumentShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeDocument(c, s.asDocumentShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of list shape deserilization functions.
+     *
+     * @param shape The list shape to generate deserialization for.
+     * @return null
+     */
+    @Override
+    public final Void listShape(ListShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeCollection(c, s.asListShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of map shape deserilization functions.
+     *
+     * @param shape The map shape to generate deserialization for.
+     * @return null
+     */
+    @Override
+    public final Void mapShape(MapShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeMap(c, s.asMapShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of set shape deserilization functions.
+     *
+     * @param shape The set shape to generate deserialization for.
+     * @return null
+     */
+    @Override
+    public final Void setShape(SetShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeCollection(c, s.asSetShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of structure shape deserilization functions.
+     *
+     * @param shape The structure shape to generate deserialization for.
+     * @return null
+     */
+    @Override
+    public final Void structureShape(StructureShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeStructure(c, s.asStructureShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of union shape deserilization functions.
+     *
+     * @param shape The union shape to generate deserialization for.
+     * @return null
+     */
+    @Override
+    public final Void unionShape(UnionShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeUnion(c, s.asUnionShape().get()));
+        return null;
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeSerVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeSerVisitor.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+
+/**
+ * Visitor to generate serialization for shapes in protocol document bodies.
+ *
+ * Visitor methods for aggregate types are final and will generate functions that dispatch
+ * their body generation to the matching abstract method.
+ *
+ * Visitor methods for all other types will default to not generating serialization functions.
+ * This may be overwritten by downstream implementations if the protocol requires a more
+ * complex serialization strategy for those types.
+ *
+ * The standard implementation is as follows; no assumptions are made about the protocol
+ * being generated for.
+ *
+ * <ul>
+ *   <li>Service, Operation, Resource: no function generated. <b>Not overridable.</b></li>
+ *   <li>Document, List, Map, Set, Structure, Union: generates a serialization function.
+ *     <b>Not overridable.</b></li>
+ *   <li>All other types: no function generated. <b>May be overridden.</b></li>
+ * </ul>
+ */
+public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void> {
+    private final GenerationContext context;
+
+    public DocumentShapeSerVisitor(GenerationContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
+    }
+
+    /**
+     * Writes the code needed to serialize a collection in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the CollectionShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The collection shape being generated.
+     */
+    protected abstract void serializeCollection(GenerationContext context, CollectionShape shape);
+
+    /**
+     * Writes the code needed to serialize a document shape in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the DocumentShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The document shape being generated.
+     */
+    protected abstract void serializeDocument(GenerationContext context, DocumentShape shape);
+
+    /**
+     * Writes the code needed to serialize a map in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the MapShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The map shape being generated.
+     */
+    protected abstract void serializeMap(GenerationContext context, MapShape shape);
+
+    /**
+     * Writes the code needed to serialize a structure in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the StructureShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The structure shape being generated.
+     */
+    protected abstract void serializeStructure(GenerationContext context, StructureShape shape);
+
+    /**
+     * Writes the code needed to serialize a union in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the UnionShape {@code shape} parameter.
+     *
+     * @param context The generation context.
+     * @param shape The union shape being generated.
+     */
+    protected abstract void serializeUnion(GenerationContext context, UnionShape shape);
+
+    /**
+     * Generates a function for serializing the input shape, dispatching the body generation
+     * to the supplied function.
+     *
+     * @param shape The shape to generate a serializer for.
+     * @param functionBody An implementation that will generate a function body to serialize the shape.
+     */
+    private void generateSerFunction(
+            Shape shape,
+            BiConsumer<GenerationContext, Shape> functionBody
+    ) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        GoWriter writer = context.getWriter();
+
+        Symbol symbol = symbolProvider.toSymbol(shape);
+        String functionName = ProtocolGenerator.getDocumentSerializerFunctionName(shape, context.getProtocolName());
+
+        String additionalArguments = getAdditionalSerArguments().entrySet().stream()
+                .map(entry -> String.format(", %s %s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining());
+
+        writer.openBlock("func $L(v $P$L) error {", "}",
+                functionName, symbol, additionalArguments, () -> {
+                    functionBody.accept(context, shape);
+                });
+        writer.write("");
+    }
+
+    /**
+     * Gets any additional arguments needed for every serializer function.
+     *
+     * For example, a json protocol may wish to pass around a {@code smithy/json.Value} builder.
+     *
+     * @return a map of argument name to argument type.
+     */
+    protected Map<String, String> getAdditionalSerArguments() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    protected Void getDefault(Shape shape) {
+        return null;
+    }
+
+    @Override
+    public final Void operationShape(OperationShape shape) {
+        throw new CodegenException("Operation shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void resourceShape(ResourceShape shape) {
+        throw new CodegenException("Resource shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void serviceShape(ServiceShape shape) {
+        throw new CodegenException("Service shapes cannot be bound to documents.");
+    }
+
+    /**
+     * Dispatches to create the body of document shape serialization functions.
+     *
+     * @param shape The document shape to generate serialization for.
+     * @return null
+     */
+    @Override
+    public final Void documentShape(DocumentShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeDocument(c, s.asDocumentShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of list shape serialization functions.
+     *
+     * @param shape The list shape to generate serialization for.
+     * @return null
+     */
+    @Override
+    public final Void listShape(ListShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeCollection(c, s.asListShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of map shape serialization functions.
+     *
+     * @param shape The map shape to generate serialization for.
+     * @return null
+     */
+    @Override
+    public final Void mapShape(MapShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeMap(c, s.asMapShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of set shape serialization functions.
+     *
+     * @param shape The set shape to generate serialization for.
+     * @return null
+     */
+    @Override
+    public final Void setShape(SetShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeCollection(c, s.asSetShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of structure shape serialization functions.
+     *
+     * @param shape The structure shape to generate serialization for.
+     * @return null
+     */
+    @Override
+    public final Void structureShape(StructureShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeStructure(c, s.asStructureShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of union shape serialization functions.
+     *
+     * @param shape The union shape to generate serialization for.
+     * @return null
+     */
+    @Override
+    public final Void unionShape(UnionShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeUnion(c, s.asUnionShape().get()));
+        return null;
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -58,9 +58,6 @@ import software.amazon.smithy.utils.OptionalUtils;
  * Abstract implementation useful for all protocols that use HTTP bindings.
  */
 public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator {
-    public static final String OPERATION_SERIALIZER_MIDDLEWARE_ID = "OperationSerializer";
-    public static final String OPERATION_DESERIALIZER_MIDDLEWARE_ID = "OperationDeserializer";
-
     private static final Logger LOGGER = Logger.getLogger(HttpBindingProtocolGenerator.class.getName());
 
     private final boolean isErrorCodeInBody;
@@ -246,8 +243,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateOperationSerializerMiddleware(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
                 ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()),
-                OPERATION_SERIALIZER_MIDDLEWARE_ID
-                );
+                ProtocolUtils.OPERATION_SERIALIZER_MIDDLEWARE_ID);
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
@@ -343,8 +339,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateOperationDeserializerMiddleware(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createDeserializeStepMiddleware(
                 ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()),
-                OPERATION_DESERIALIZER_MIDDLEWARE_ID
-                );
+                ProtocolUtils.OPERATION_DESERIALIZER_MIDDLEWARE_ID);
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -66,8 +66,7 @@ public final class HttpProtocolGeneratorUtils {
 
             // Copy the response body into a seekable type
             writer.write("var errorBuffer bytes.Buffer");
-            writer.write("_, err := io.Copy(&errorBuffer, response.Body)");
-            writer.openBlock("if err != nil {", "}", () -> {
+            writer.openBlock("if _, err := io.Copy(&errorBuffer, response.Body); err != nil {", "}", () -> {
                 writer.write("return &smithy.DeserializationError{Err: fmt.Errorf("
                         + "\"failed to copy error response body, %w\", err)}");
             });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+public final class HttpProtocolGeneratorUtils {
+
+    private HttpProtocolGeneratorUtils() {}
+
+    /**
+     * Generates a function that handles error deserialization by getting the error code then
+     * dispatching to the error-specific deserializer.
+     *
+     * If the error code does not map to a known error, a generic error will be returned using
+     * the error code and error message discovered in the response.
+     *
+     * The default error message and code are both "UnknownError".
+     *
+     * @param context The generation context.
+     * @param operation The operation to generate for.
+     * @param responseType The response type for the HTTP protocol.
+     * @param errorMessageCodeGenerator A consumer that generates a snippet that sets the {@code errorCode}
+     *                                  and {@code errorMessage} variables from the http response.
+     * @return A set of all error structure shapes for the operation that were dispatched to.
+     */
+    static Set<StructureShape> generateErrorDispatcher(
+            GenerationContext context,
+            OperationShape operation,
+            Symbol responseType,
+            Consumer<GenerationContext> errorMessageCodeGenerator
+    ) {
+        GoWriter writer = context.getWriter();
+        Set<StructureShape> errorShapes = new TreeSet<>();
+
+        String errorFunctionName = ProtocolGenerator.getOperationErrorDeserFunctionName(
+                operation, context.getProtocolName());
+
+        writer.openBlock("func $L(response $P) error {", "}", errorFunctionName, responseType, () -> {
+            writer.addUseImports(SmithyGoDependency.BYTES);
+            writer.addUseImports(SmithyGoDependency.IO);
+            writer.addUseImports(SmithyGoDependency.SMITHY_IO);
+            writer.write("defer response.Body.Close()");
+            writer.write("");
+
+            // Copy the response body into a seekable type
+            writer.write("var errorBuffer bytes.Buffer");
+            writer.write("_, err := io.Copy(&errorBuffer, response.Body)");
+            writer.openBlock("if err != nil {", "}", () -> {
+                writer.write("return &smithy.DeserializationError{Err: fmt.Errorf("
+                        + "\"failed to copy error response body, %w\", err)}");
+            });
+            writer.write("errorBody := bytes.NewReader(errorBuffer.Bytes())");
+            writer.write("");
+
+            // Set the default values for code and message.
+            writer.write("errorCode := \"UnknownError\"");
+            writer.write("errorMessage := errorCode");
+            writer.write("");
+
+            // Dispatch to the message/code generator to try to get the specific code and message.
+            errorMessageCodeGenerator.accept(context);
+
+            writer.openBlock("switch errorCode {", "}", () -> {
+                new TreeSet<>(operation.getErrors()).forEach(errorId -> {
+                    StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
+                    errorShapes.add(error);
+                    String errorDeserFunctionName = ProtocolGenerator.getErrorDeserFunctionName(
+                            error, context.getProtocolName());
+                    writer.openBlock("case $S:", "", errorId.getName(), () -> {
+                        writer.write("return $L(response, errorBody)", errorDeserFunctionName);
+                    });
+                });
+
+                // Create a generic error
+                writer.addUseImports(SmithyGoDependency.SMITHY);
+                writer.openBlock("default:", "", () -> {
+                    writer.openBlock("genericError := &smithy.GenericAPIError{", "}", () -> {
+                        writer.write("Code: errorCode,");
+                        writer.write("Message: errorMessage,");
+                    });
+                    writer.write("return genericError");
+                });
+            });
+        });
+        writer.write("");
+
+        return errorShapes;
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -96,8 +96,9 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
         ApplicationProtocol applicationProtocol = getApplicationProtocol();
         Symbol requestType = applicationProtocol.getRequestType();
+        GoWriter writer = context.getWriter();
 
-        middleware.writeMiddleware(context.getWriter(), (generator, writer) -> {
+        middleware.writeMiddleware(context.getWriter(), (generator, w) -> {
             writer.addUseImports(SmithyGoDependency.SMITHY);
             writer.addUseImports(SmithyGoDependency.FMT);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
@@ -128,7 +129,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.write("");
 
             // delegate the setup and usage of the document serializer function for the protocol
-            serializeInputDocument(model, symbolProvider, operation, generator, writer);
+            serializeInputDocument(context, operation);
             serializingDocumentShapes.add(ProtocolUtils.expectInput(model, operation));
             writer.write("");
 
@@ -185,19 +186,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      *   <li>{@code ctx: context.Context}: a type containing context and tools for type serde.</li>
      * </ul>
      *
-     * @param model          the model
-     * @param symbolProvider the symbol provider
-     * @param operation      the operation
-     * @param generator      middleware generator definition
-     * @param writer         the writer within the middleware context
+     * @param context The generation context.
+     * @param operation The operation to serialize for.
      */
-    protected abstract void serializeInputDocument(
-            Model model,
-            SymbolProvider symbolProvider,
-            OperationShape operation,
-            GoStackStepMiddlewareGenerator generator,
-            GoWriter writer
-    );
+    protected abstract void serializeInputDocument(GenerationContext context, OperationShape operation);
 
     @Override
     public void generateSharedDeserializerComponents(GenerationContext context) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -88,7 +88,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
     private void generateOperationSerializer(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
-                ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()));
+                ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()),
+                ProtocolUtils.OPERATION_SERIALIZER_MIDDLEWARE_ID);
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
@@ -221,7 +222,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
     private void generateOperationDeserializer(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createDeserializeStepMiddleware(
-                ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()));
+                ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()),
+                ProtocolUtils.OPERATION_DESERIALIZER_MIDDLEWARE_ID);
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.ApplicationProtocol;
+import software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
+
+    private final boolean isErrorCodeInBody;
+    private final Set<Shape> serializingDocumentShapes = new TreeSet<>();
+
+    /**
+     * Creates a Http RPC protocol generator.
+     *
+     * @param isErrorCodeInBody A boolean that indicates if the error code for the implementing protocol is located in
+     *   the error response body, meaning this generator will parse the body before attempting to load an error code.
+     */
+    public HttpRpcProtocolGenerator(boolean isErrorCodeInBody) {
+        this.isErrorCodeInBody = isErrorCodeInBody;
+    }
+
+    @Override
+    public ApplicationProtocol getApplicationProtocol() {
+        return ApplicationProtocol.createDefaultHttpApplicationProtocol();
+    }
+
+    /**
+     * Gets the content-type for a request body.
+     *
+     * @return Returns the default content-type.
+     */
+    protected abstract String getDocumentContentType();
+
+    @Override
+    public void generateSharedSerializerComponents(GenerationContext context) {
+        serializingDocumentShapes.addAll(ProtocolUtils.resolveRequiredDocumentShapeSerde(
+                context.getModel(), serializingDocumentShapes));
+        generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
+    }
+
+    /**
+     * Generates serialization functions for shapes in the passed set. These functions
+     * should return a value that can then be serialized by the implementation of
+     * {@code serializeInputDocument}.
+     *
+     * @param context The generation context.
+     * @param shapes  The shapes to generate serialization for.
+     */
+    protected abstract void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes);
+
+    @Override
+    public void generateRequestSerializers(GenerationContext context) {
+        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+
+        Set<OperationShape> containedOperations = new TreeSet<>(
+                topDownIndex.getContainedOperations(context.getService()));
+        for (OperationShape operation : containedOperations) {
+            generateOperationSerializer(context, operation);
+        }
+    }
+
+    private void generateOperationSerializer(GenerationContext context, OperationShape operation) {
+        GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
+                ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()));
+
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        Model model = context.getModel();
+        Shape inputShape = ProtocolUtils.expectInput(model, operation);
+        Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
+        ApplicationProtocol applicationProtocol = getApplicationProtocol();
+        Symbol requestType = applicationProtocol.getRequestType();
+
+        middleware.writeMiddleware(context.getWriter(), (generator, writer) -> {
+            writer.addUseImports(SmithyGoDependency.SMITHY);
+            writer.addUseImports(SmithyGoDependency.FMT);
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
+
+            // Cast the input request to the transport request type and check for errors.
+            writer.write("request, ok := in.Request.($P)", requestType);
+            writer.openBlock("if !ok {", "}", () -> {
+                writer.write("return out, metadata, "
+                        + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown transport type %T\", in.Request)}");
+            }).write("");
+
+            // Cast the input parameters to the operation request type and check for errors.
+            writer.write("input, ok := in.Parameters.($P)", inputSymbol);
+            writer.openBlock("if !ok {", "}", () -> {
+                writer.write("return out, metadata, "
+                        + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
+                        + " in.Parameters)}");
+            }).write("");
+
+            writer.write("request.Request.URL.Path = $S", getOperationPath(context, operation));
+            writer.write("request.Request.Method = \"POST\"");
+            writer.write("httpBindingEncoder, err := httpbinding.NewEncoder(request.URL.Path, "
+                    +  "request.URL.RawQuery, request.Header)");
+            writer.openBlock("if err != nil {", "}", () -> {
+                writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
+            });
+            writeRequestHeaders(context, operation, writer);
+            writer.write("");
+
+            // delegate the setup and usage of the document serializer function for the protocol
+            serializeInputDocument(model, symbolProvider, operation, generator, writer);
+            serializingDocumentShapes.add(ProtocolUtils.expectInput(model, operation));
+            writer.write("");
+
+            writer.openBlock("if request.Request, err = httpBindingEncoder.Encode(request.Request); err != nil {",
+                    "}", () -> {
+                writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
+            });
+            // Ensure the request value is updated if modified for a document.
+            writer.write("in.Request = request");
+
+            writer.write("");
+            writer.write("return next.$L(ctx, in)", generator.getHandleMethodName());
+        });
+    }
+
+    private void writeRequestHeaders(GenerationContext context, OperationShape operation, GoWriter writer) {
+        writer.write("httpBindingEncoder.SetHeader(\"Content-Type\").String($S)", getDocumentContentType());
+        writeDefaultHeaders(context, operation, writer);
+    }
+
+    /**
+     * Writes any additional HTTP headers required by the protocol implementation.
+     *
+     * <p>Four parameters will be available in scope:
+     * <ul>
+     *   <li>{@code input: <T>}: the type generated for the operation's input.</li>
+     *   <li>{@code request: smithyhttp.HTTPRequest}: the HTTP request that will be sent.</li>
+     *   <li>{@code httpBindingEncoder: httpbinding.Encoder}: the HTTP encoder to use to set the headers.</li>
+     *   <li>{@code ctx: context.Context}: a type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * @param context The generation context.
+     * @param operation The operation being generated.
+     * @param writer The writer to use.
+     */
+    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation, GoWriter writer) {}
+
+    /**
+     * Provides the request path for the operation.
+     *
+     * @param context The generation context.
+     * @param operation The operation being generated.
+     * @return The path to send HTTP requests to.
+     */
+    protected abstract String getOperationPath(GenerationContext context, OperationShape operation);
+
+    /**
+     * Generate the document serializer logic for the serializer middleware body.
+     *
+     * <p>Three parameters will be available in scope:
+     * <ul>
+     *   <li>{@code input: <T>}: the type generated for the operation's input.</li>
+     *   <li>{@code request: smithyhttp.HTTPRequest}: the HTTP request that will be sent.</li>
+     *   <li>{@code ctx: context.Context}: a type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * @param model          the model
+     * @param symbolProvider the symbol provider
+     * @param operation      the operation
+     * @param generator      middleware generator definition
+     * @param writer         the writer within the middleware context
+     */
+    protected abstract void serializeInputDocument(
+            Model model,
+            SymbolProvider symbolProvider,
+            OperationShape operation,
+            GoStackStepMiddlewareGenerator generator,
+            GoWriter writer
+    );
+
+    @Override
+    public void generateResponseDeserializers(GenerationContext context) {
+        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+        Set<OperationShape> containedOperations = new TreeSet<>(
+                topDownIndex.getContainedOperations(context.getService()));
+        for (OperationShape operation : containedOperations) {
+            generateOperationDeserializer(context, operation);
+        }
+    }
+
+    private void generateOperationDeserializer(GenerationContext context, OperationShape operation) {
+        GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createDeserializeStepMiddleware(
+                ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()));
+        StructureShape outputShape = ProtocolUtils.expectOutput(context.getModel(), operation);
+        middleware.writeMiddleware(context.getWriter(), (generator, writer) -> {
+            // TODO: actually implement this
+            writer.write("out, metadata, err = next.$L(ctx, in)", generator.getHandleMethodName());
+            writer.write("if err != nil { return out, metadata, err }");
+            writer.write("");
+
+            writer.write("output := &$T{}", context.getSymbolProvider().toSymbol(outputShape));
+            writer.write("out.Result = output");
+            writer.write("");
+            writer.write("return out, metadata, err");
+        });
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -264,7 +264,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.write("out.Result = output");
             writer.write("");
 
-            deserializeOutputDocument(model, symbolProvider, operation, generator, writer);
+            deserializeOutputDocument(context, operation);
             deserializingDocumentShapes.add(ProtocolUtils.expectOutput(model, operation));
             writer.write("");
 
@@ -288,19 +288,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      *   <li>{@code ctx: context.Context}: a type containing context and tools for type serde.</li>
      * </ul>
      *
-     * @param model The model.
-     * @param symbolProvider The symbol provider.
+     * @param context The generation context
      * @param operation The operation to deserialize for.
-     * @param generator The middleware generator definition.
-     * @param writer The GoWriter to use.
      */
-    protected abstract void deserializeOutputDocument(
-            Model model,
-            SymbolProvider symbolProvider,
-            OperationShape operation,
-            GoStackStepMiddlewareGenerator generator,
-            GoWriter writer
-    );
+    protected abstract void deserializeOutputDocument(GenerationContext context, OperationShape operation);
 
     private void generateErrorDeserializer(GenerationContext context, StructureShape shape) {
         GoWriter writer = context.getWriter();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -98,6 +98,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.addUseImports(SmithyGoDependency.FMT);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
 
+            // TODO: refactor the http binding encoder to be split up into its component parts
+            // This would allow most of this shared code to be split off into its own function
+            // to reduce duplication, and potentially allowing it to be a static function.
+            // For example, a HeaderBag type could handle all the headers.
             // Cast the input request to the transport request type and check for errors.
             writer.write("request, ok := in.Request.($P)", requestType);
             writer.openBlock("if !ok {", "}", () -> {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -31,20 +31,14 @@ import software.amazon.smithy.model.shapes.StructureShape;
 
 public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
-    private final boolean isErrorCodeInBody;
     private final Set<Shape> serializingDocumentShapes = new TreeSet<>();
     private final Set<Shape> deserializingDocumentShapes = new TreeSet<>();
     private final Set<StructureShape> deserializingErrorShapes = new TreeSet<>();
 
     /**
-     * Creates a Http RPC protocol generator.
-     *
-     * @param isErrorCodeInBody A boolean that indicates if the error code for the implementing protocol is located in
-     *   the error response body, meaning this generator will parse the body before attempting to load an error code.
+     * Creates an Http RPC protocol generator.
      */
-    public HttpRpcProtocolGenerator(boolean isErrorCodeInBody) {
-        this.isErrorCodeInBody = isErrorCodeInBody;
-    }
+    public HttpRpcProtocolGenerator() { }
 
     @Override
     public ApplicationProtocol getApplicationProtocol() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -25,9 +25,11 @@ import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.StringUtils;
@@ -225,6 +227,14 @@ public interface ProtocolGenerator {
      */
     static String getDocumentOutputDeserializerFunctionName(Shape shape, String protocol) {
         return protocol + "_deserializeOpDocument" + StringUtils.capitalize(shape.getId().getName());
+    }
+
+    static String getOperationErrorDeserFunctionName(OperationShape shape, String protocol) {
+        return protocol + "_deserializeOpError" + StringUtils.capitalize(shape.getId().getName());
+    }
+
+    static String getErrorDeserFunctionName(StructureShape shape, String protocol) {
+        return protocol + "_deserializeError" + StringUtils.capitalize(shape.getId().getName());
     }
 
     static String getSerializeMiddlewareName(ShapeId operationShapeId, String protocol) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -32,6 +32,9 @@ import software.amazon.smithy.utils.SetUtils;
  * Utility functions for protocol generation.
  */
 public final class ProtocolUtils {
+    public static final String OPERATION_SERIALIZER_MIDDLEWARE_ID = "OperationSerializer";
+    public static final String OPERATION_DESERIALIZER_MIDDLEWARE_ID = "OperationDeserializer";
+
     private static final Set<ShapeType> REQUIRES_SERDE = SetUtils.of(
             ShapeType.MAP, ShapeType.LIST, ShapeType.SET, ShapeType.DOCUMENT, ShapeType.STRUCTURE, ShapeType.UNION);
     private static final Set<RelationshipType> MEMBER_RELATIONSHIPS = SetUtils.of(

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.neighbor.RelationshipType;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -87,7 +88,7 @@ public final class ProtocolUtils {
      * @return The operation's input as a structure shape.
      */
     public static StructureShape expectInput(Model model, OperationShape operation) {
-        return operation.getInput().flatMap(model::getShape).flatMap(Shape::asStructureShape)
+        return model.getKnowledge(OperationIndex.class).getInput(operation)
                 .orElseThrow(() -> new CodegenException(
                         "Expected input shape for operation " + operation.getId().toString()));
     }
@@ -100,7 +101,7 @@ public final class ProtocolUtils {
      * @return The operation's output as a structure shape.
      */
     public static StructureShape expectOutput(Model model, OperationShape operation) {
-        return operation.getOutput().flatMap(model::getShape).flatMap(Shape::asStructureShape)
+        return model.getKnowledge(OperationIndex.class).getOutput(operation)
                 .orElseThrow(() -> new CodegenException(
                         "Expected output shape for operation " + operation.getId().toString()));
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.neighbor.RelationshipType;
+import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.SetUtils;
+
+/**
+ * Utility functions for protocol generation.
+ */
+public final class ProtocolUtils {
+    private static final Set<ShapeType> REQUIRES_SERDE = SetUtils.of(
+            ShapeType.MAP, ShapeType.LIST, ShapeType.SET, ShapeType.DOCUMENT, ShapeType.STRUCTURE, ShapeType.UNION);
+    private static final Set<RelationshipType> MEMBER_RELATIONSHIPS = SetUtils.of(
+            RelationshipType.STRUCTURE_MEMBER, RelationshipType.UNION_MEMBER, RelationshipType.LIST_MEMBER,
+            RelationshipType.SET_MEMBER, RelationshipType.MAP_VALUE, RelationshipType.MEMBER_TARGET
+    );
+
+    private ProtocolUtils() {}
+
+    /**
+     * Resolves the entire set of shapes that will require serde given an initial set of shapes.
+     *
+     * @param model  the model
+     * @param shapes the shapes to walk and resolve additional required serializers, deserializers for
+     * @return the complete set of shapes requiring serializers, deserializers
+     */
+    public static Set<Shape> resolveRequiredDocumentShapeSerde(Model model, Set<Shape> shapes) {
+        Set<ShapeId> processed = new TreeSet<>();
+        Set<Shape> resolvedShapes = new TreeSet<>();
+        Walker walker = new Walker(model);
+
+        shapes.forEach(shape -> {
+            processed.add(shape.getId());
+            resolvedShapes.add(shape);
+            walker.iterateShapes(shape, relationship -> MEMBER_RELATIONSHIPS.contains(
+                    relationship.getRelationshipType()))
+                    .forEachRemaining(walkedShape -> {
+                        // MemberShape type itself is not what we are interested in
+                        if (walkedShape.getType() == ShapeType.MEMBER) {
+                            return;
+                        }
+                        if (processed.contains(walkedShape.getId())) {
+                            return;
+                        }
+                        if (REQUIRES_SERDE.contains(walkedShape.getType())) {
+                            resolvedShapes.add(walkedShape);
+                            processed.add(walkedShape.getId());
+                        }
+                    });
+        });
+
+        return resolvedShapes;
+    }
+
+    /**
+     * Gets the operation input as a structure shape or throws an exception.
+     *
+     * @param model The model that contains the operation.
+     * @param operation The operation to get the input from.
+     * @return The operation's input as a structure shape.
+     */
+    public static StructureShape expectInput(Model model, OperationShape operation) {
+        return operation.getInput().flatMap(model::getShape).flatMap(Shape::asStructureShape)
+                .orElseThrow(() -> new CodegenException(
+                        "Expected input shape for operation " + operation.getId().toString()));
+    }
+
+    /**
+     * Gets the operation output as a structure shape or throws an exception.
+     *
+     * @param model The model that contains the operation.
+     * @param operation The operation to get the output from.
+     * @return The operation's output as a structure shape.
+     */
+    public static StructureShape expectOutput(Model model, OperationShape operation) {
+        return operation.getOutput().flatMap(model::getShape).flatMap(Shape::asStructureShape)
+                .orElseThrow(() -> new CodegenException(
+                        "Expected output shape for operation " + operation.getId().toString()));
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This add support for http rpc protocols. There is some refactoring work done here, mostly in ProtocolUtils, to reduce copied code, but existing code is as of yet still intact.

related: https://github.com/aws/aws-sdk-go-v2/pull/599

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
