### PR TITLE
remove explicit go compile check from smithy-go

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -31,3 +31,11 @@ dependencies {
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.0.2,1.1.0[")
     implementation(project(":smithy-go-codegen"))
 }
+
+// ensure built artifacts are put into the SDK's folders
+tasks.create<Exec>("verifyGoCodegen") {
+    dependsOn ("build")
+    workingDir("$buildDir/smithyprojections/smithy-go-codegen-test/source/go-codegen")
+    commandLine ("go", "test", "-run", "NONE", "./...")
+}
+tasks["build"].finalizedBy(tasks["verifyGoCodegen"])

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -199,10 +199,6 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         LOGGER.fine("Running go fmt");
         CodegenUtils.runCommand("go fmt", fileManifest.getBaseDir());
-
-        // TODO this should be moved to a smithy gradle task
-        LOGGER.fine("Running go build");
-        CodegenUtils.runCommand("go test -run NONE ./...", fileManifest.getBaseDir());
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -198,7 +198,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         GoModGenerator.writeGoMod(settings, fileManifest, SymbolDependency.gatherDependencies(dependencies.stream()));
 
         LOGGER.fine("Running go fmt");
-        CodegenUtils.runCommand("go fmt", fileManifest.getBaseDir());
+        CodegenUtils.runCommand("gofmt -w -s .", fileManifest.getBaseDir());
     }
 
     @Override


### PR DESCRIPTION
Removes explicit go compile check for all smithy-go generated clients. Moves the validation into the `smithy-go-codegen-test` module to validate that the individual test compiles.

All other generated client validation in `aws-sdk-go-v2` is handled via coping from their generated output locations, and validated via the SDK's make tasks.