### PR TITLE
fix setting stream not updating request

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -318,6 +318,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 writeMiddlewarePayloadSerializerDelegator(model, symbolProvider, operation, memberShape, generator,
                         writer);
             }
+            // Ensure the request value is updated if modified for a document.
+            writer.write("in.Request = request");
 
             writer.write("");
             writer.openBlock("if err := restEncoder.Encode(); err != nil {", "}", () -> {


### PR DESCRIPTION
Fixes the bug with protocol tests failing because the streaming body was always nil. This ensures that the updated request value is always added back to the input for passing down to the next handler.