### PR TITLE
Update protocol tests to validate RawPath

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
@@ -189,7 +189,7 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
         writeAssertNotNil(writer, "result");
 
         writeAssertScalarEqual(writer, "c.ExpectMethod", "actualReq.Method", "method");
-        writeAssertScalarEqual(writer, "c.ExpectURIPath", "actualReq.URL.Path", "path");
+        writeAssertScalarEqual(writer, "c.ExpectURIPath", "actualReq.URL.RawPath", "path");
 
         writeQueryItemBreakout(writer, "actualReq.URL.RawQuery", "queryItems");
         writeAssertHasQuery(writer, "c.ExpectQuery", "queryItems");


### PR DESCRIPTION
Modifies Smithy code generation to correctly validate URI encoding using `RawPath` rather then `Path`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
