### PR TITLE
HTTP Binding Encoder Changes

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -95,6 +95,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200621224423-542121c5d59c";
+        private static final String SMITHY_GO = "v0.0.0-20200623232658-13872e2cd522";
     }
 }

--- a/httpbinding/encode_test.go
+++ b/httpbinding/encode_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestEncoder(t *testing.T) {
-	actual := http.Request{
+	actual := &http.Request{
 		Header: http.Header{
 			"custom-user-header": {"someValue"},
 		},
@@ -18,7 +18,7 @@ func TestEncoder(t *testing.T) {
 		},
 	}
 
-	expected := http.Request{
+	expected := &http.Request{
 		Header: map[string][]string{
 			"custom-user-header": {"someValue"},
 			"X-Amzn-Header-Foo":  {"someValue"},
@@ -31,7 +31,10 @@ func TestEncoder(t *testing.T) {
 		},
 	}
 
-	encoder := NewEncoder(&actual)
+	encoder, err := NewEncoder(actual.URL.Path, actual.URL.RawQuery, actual.Header)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
 	// Headers
 	encoder.AddHeader("x-amzn-header-foo").String("someValue")
@@ -51,7 +54,7 @@ func TestEncoder(t *testing.T) {
 		t.Errorf("expected no err, but got %v", err)
 	}
 
-	if err := encoder.Encode(); err != nil {
+	if actual, err = encoder.Encode(actual); err != nil {
 		t.Errorf("expected no err, but got %v", err)
 	}
 


### PR DESCRIPTION
Changes the HTTP Binding encoder design to avoid issues with referencing potentially out of date references to `net/http.Request` types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
