### PR TITLE
Refactor protocol test body to use test server to validate http request

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -30,6 +30,7 @@ public final class SmithyGoDependency {
     public static final GoDependency BASE64 = stdlib("encoding/base64");
     public static final GoDependency NET_URL = stdlib("net/url");
     public static final GoDependency NET_HTTP = stdlib("net/http");
+    public static final GoDependency NET_HTTP_TEST = stdlib("net/http/httptest");
     public static final GoDependency BYTES = stdlib("bytes");
     public static final GoDependency STRINGS = stdlib("strings");
     public static final GoDependency JSON = stdlib("encoding/json");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
@@ -189,7 +189,7 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
     @Override
     protected void generateTestInvokeClientOperation(GoWriter writer, String clientName) {
         writer.addUseImports(SmithyGoDependency.CONTEXT);
-        writer.write("result, err := $L.$L(context.Background(), c.Params)", clientName, opSymbol.getName());
+        writer.write("result, err := $L.$T(context.Background(), c.Params)", clientName, opSymbol);
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
@@ -123,7 +123,11 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
         writer.openBlock("if len(c.Body) != 0 {", "}", () -> {
             writer.addUseImports(SmithyGoDependency.STRCONV);
             writer.write("w.Header().Set(\"Content-Length\", strconv.Itoa(len(c.Body)))");
+        });
 
+        writer.write("w.WriteHeader(c.StatusCode)");
+
+        writer.openBlock("if len(c.Body) != 0 {", "}", () -> {
             writer.addUseImports(SmithyGoDependency.IO);
             writer.addUseImports(SmithyGoDependency.BYTES);
             writer.openBlock("if _, err := io.Copy(w, bytes.NewReader(c.Body)); err != nil {", "}", () -> {
@@ -142,7 +146,7 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
     protected void generateTestInvokeClientOperation(GoWriter writer, String clientName) {
         writer.addUseImports(SmithyGoDependency.CONTEXT);
         writer.write("var params $T", inputSymbol);
-        writer.write("result, err := $L.$L(context.Background(), &params)", clientName, opSymbol.getName());
+        writer.write("result, err := $L.$T(context.Background(), &params)", clientName, opSymbol);
     }
 
     /**


### PR DESCRIPTION
Refactors protocol test body breaking it up into multiple segments `setup`, `test server`, `test client`, and `client operation` This allows for more fine grained overriding of the protocol tests's generated code and behavior.  

Adds a test HTTP server to the protocol tests to exercise more real world request serialization/deserialization behavior.