### PR TITLE
Add sort order to implementations of GoIntegrations

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -68,8 +68,8 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
     }
 
     /**
-	 * Gets the sort order of the customization from -128 to 127, with lowest
-	 * executed first.
+     * Gets the sort order of the customization from -128 to 127, with lowest
+     * executed first.
      *
      * @return Returns the sort order, defaults to 10.
      */

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -68,16 +68,10 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
     }
 
     /**
-     * Gets the sort order of the customization from -128 to 127.
+	 * Gets the sort order of the customization from -128 to 127, with lowest
+	 * executed first.
      *
-     * <p>Customizations are applied according to this sort order. Lower values
-     * are executed before higher values (for example, -128 comes before 0,
-     * comes before 127). Customizations default to 0, which is the middle point
-     * between the minimum and maximum order values. The customization
-     * applied later can override the runtime configurations that provided
-     * by customizations applied earlier.
-     *
-     * @return Returns the sort order, defaulting to 0.
+     * @return Returns the sort order, defaults to 10.
      */
     @Override
     public byte getOrder() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -67,6 +67,23 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
         });
     }
 
+    /**
+     * Gets the sort order of the customization from -128 to 127.
+     *
+     * <p>Customizations are applied according to this sort order. Lower values
+     * are executed before higher values (for example, -128 comes before 0,
+     * comes before 127). Customizations default to 0, which is the middle point
+     * between the minimum and maximum order values. The customization
+     * applied later can override the runtime configurations that provided
+     * by customizations applied earlier.
+     *
+     * @return Returns the sort order, defaulting to 0.
+     */
+    @Override
+    public byte getOrder() {
+        return 10;
+    }
+
     @Override
     public void writeAdditionalFiles(
             GoSettings settings,

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
@@ -57,16 +57,10 @@ import software.amazon.smithy.utils.StringUtils;
  */
 public class ValidationGenerator implements GoIntegration {
     /**
-     * Gets the sort order of the customization from -128 to 127.
+	 * Gets the sort order of the customization from -128 to 127, with lowest
+	 * executed first.
      *
-     * <p>Customizations are applied according to this sort order. Lower values
-     * are executed before higher values (for example, -128 comes before 0,
-     * comes before 127). Customizations default to 0, which is the middle point
-     * between the minimum and maximum order values. The customization
-     * applied later can override the runtime configurations that provided
-     * by customizations applied earlier.
-     *
-     * @return Returns the sort order, defaulting to 0.
+     * @return Returns the sort order, defaults to 20.
      */
     @Override
     public byte getOrder() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
@@ -56,6 +56,23 @@ import software.amazon.smithy.utils.StringUtils;
  * Generates Go validation middleware and shape helpers.
  */
 public class ValidationGenerator implements GoIntegration {
+    /**
+     * Gets the sort order of the customization from -128 to 127.
+     *
+     * <p>Customizations are applied according to this sort order. Lower values
+     * are executed before higher values (for example, -128 comes before 0,
+     * comes before 127). Customizations default to 0, which is the middle point
+     * between the minimum and maximum order values. The customization
+     * applied later can override the runtime configurations that provided
+     * by customizations applied earlier.
+     *
+     * @return Returns the sort order, defaulting to 0.
+     */
+    @Override
+    public byte getOrder() {
+        return 20;
+    }
+
     private void execute(GoWriter writer, Model model, SymbolProvider symbolProvider, ServiceShape service) {
         GoValidationIndex validationIndex = model.getKnowledge(GoValidationIndex.class);
         Map<Shape, OperationShape> inputShapeToOperation = new TreeMap<>();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
@@ -57,8 +57,8 @@ import software.amazon.smithy.utils.StringUtils;
  */
 public class ValidationGenerator implements GoIntegration {
     /**
-	 * Gets the sort order of the customization from -128 to 127, with lowest
-	 * executed first.
+     * Gets the sort order of the customization from -128 to 127, with lowest
+     * executed first.
      *
      * @return Returns the sort order, defaults to 20.
      */


### PR DESCRIPTION
Adds sorting order to GoIntegrations to help improve consistent code generation order.