### PR TITLE
fixup HTTP protocol test handling of request URL path vs raw path

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
@@ -168,6 +168,9 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
      */
     protected void generateTestServerHandler(GoWriter writer) {
         writer.write("actualReq = r.Clone(r.Context())");
+        // Go does not set RawPath on http server if nothing is excaped
+        writer.write("if len(actualReq.URL.RawPath) == 0 { actualReq.URL.RawPath = actualReq.URL.Path }");
+
         writer.addUseImports(SmithyGoDependency.BYTES);
         writer.write("var buf bytes.Buffer");
         writer.openBlock("if _, err := io.Copy(&buf, r.Body); err != nil {", "}", () -> {


### PR DESCRIPTION
Fixes regression in HTTP protocol test's handling of request URL path vs raw path. The Go HTTP server does not set request's URL.RawPath value if the received request message's Path does not contain escaping. Fixes this by setting RawPath if unset.