### PR TITLE
Fixup header value, list, and prefix (de)serialization

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -995,6 +995,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             String operand
     ) {
         if (targetShape.getType() != ShapeType.LIST && targetShape.getType() != ShapeType.SET) {
+            writer.addUseImports(SmithyGoDependency.STRINGS);
             writer.write("$L = strings.TrimSpace($L)", operand, operand);
         }
 


### PR DESCRIPTION
Updates how HTTP header bindings are generated for (de)serialization to correctly serialize and deserialize header prefix, header values, and lists. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
