### PR TITLE
Add HasHeader to rest Encoder to check if a header value has been set

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.model.knowledge.HttpBindingIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -709,9 +710,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     }
                     break;
                 case PREFIX_HEADERS:
-                    MemberShape valueMemberShape = targetShape.asMapShape()
-                            .orElseThrow(() -> new CodegenException("prefix headers must target map shape"))
-                            .getValue();
+                    MemberShape valueMemberShape = model.expectShape(targetShape.getId(), MapShape.class).getValue();
                     Shape valueMemberTarget = model.expectShape(valueMemberShape.getTarget());
 
                     bodyWriter.write("hv := encoder.Headers($S)", memberName);

--- a/httpbinding/encode.go
+++ b/httpbinding/encode.go
@@ -65,6 +65,12 @@ func (e *Encoder) Headers(prefix string) Headers {
 	}
 }
 
+// HasHeader returns if a header with the key specified exists with one more
+// more value.
+func (e Encoder) HasHeader(Key string) bool {
+	return len(e.header.Values(Key)) != 0
+}
+
 // SetURI returns a URIValue used for setting the given path key
 func (e *Encoder) SetURI(key string) URIValue {
 	return newURIValue(&e.path, &e.rawPath, &e.pathBuffer, key)

--- a/httpbinding/encode_test.go
+++ b/httpbinding/encode_test.go
@@ -62,3 +62,21 @@ func TestEncoder(t *testing.T) {
 		t.Errorf("expected %v, but got %v", expected, actual)
 	}
 }
+
+func TestEncoderHasHeader(t *testing.T) {
+	encoder, err := NewEncoder("/", "", http.Header{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if h := "I-dont-exist"; encoder.HasHeader(h) {
+		t.Errorf("expect %v not to be set", h)
+	}
+
+	encoder.AddHeader("I-do-exist").String("some value")
+
+	if h := "I-do-exist"; !encoder.HasHeader(h) {
+		t.Errorf("expect %v to be set", h)
+	}
+
+}


### PR DESCRIPTION
Adds an additional method to Encoder to determine if a header has been set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
