### PR TITLE
Update SDKs middleware generation utils to separate name from id

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -85,6 +85,7 @@ public final class GoStackStepMiddlewareGenerator {
      * Create a new SerializeStep middleware generator with the provided type name.
      *
      * @param name is the type name to identify the middleware.
+     * @param id   the unique ID for the middleware.
      * @return the middleware generator.
      */
     public static GoStackStepMiddlewareGenerator createSerializeStepMiddleware(String name, String id) {
@@ -100,6 +101,7 @@ public final class GoStackStepMiddlewareGenerator {
      * Create a new DeserializeStep middleware generator with the provided type name.
      *
      * @param name is the type name to identify the middleware.
+     * @param id   the unique ID for the middleware.
      * @return the middleware generator.
      */
     public static GoStackStepMiddlewareGenerator createDeserializeStepMiddleware(String name, String id) {
@@ -116,6 +118,7 @@ public final class GoStackStepMiddlewareGenerator {
      * Generates a new step middleware generator.
      *
      * @param name              the name of the middleware type.
+     * @param id   the unique ID for the middleware.
      * @param handlerMethodName method name to be implemented.
      * @param inputType         the middleware input type.
      * @param outputType        the middleware output type.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -28,6 +28,7 @@ public final class GoStackStepMiddlewareGenerator {
             "Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE).build();
 
     private final Symbol middlewareSymbol;
+    private final String middlewareId;
     private final String handleMethodName;
     private final Symbol inputType;
     private final Symbol outputType;
@@ -39,7 +40,8 @@ public final class GoStackStepMiddlewareGenerator {
      * @param builder the builder to create the generator with.
      */
     public GoStackStepMiddlewareGenerator(Builder builder) {
-        this.middlewareSymbol = SymbolUtils.createPointableSymbolBuilder(builder.identifier).build();
+        this.middlewareSymbol = SymbolUtils.createPointableSymbolBuilder(builder.name).build();
+        this.middlewareId = builder.id;
         this.handleMethodName = builder.handleMethodName;
         this.inputType = builder.inputType;
         this.outputType = builder.outputType;
@@ -47,13 +49,15 @@ public final class GoStackStepMiddlewareGenerator {
     }
 
     /**
-     * Create a new InitalizeStep middleware generator with the provided type name.
+     * Create a new InitializeStep middleware generator with the provided type name.
      *
-     * @param identifier is the type name to identify the middleware.
+     * @param name is the type name to identify the middleware.
+     * @param id   the unique ID for the middleware.
      * @return the middleware generator.
      */
-    public static GoStackStepMiddlewareGenerator createInitalizeStepMiddleware(String identifier) {
-        return createMiddleware(identifier,
+    public static GoStackStepMiddlewareGenerator createInitializeStepMiddleware(String name, String id) {
+        return createMiddleware(name,
+                id,
                 "HandleInitialize",
                 SymbolUtils.createValueSymbolBuilder("InitializeInput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
                 SymbolUtils.createValueSymbolBuilder("InitializeOutput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
@@ -64,11 +68,13 @@ public final class GoStackStepMiddlewareGenerator {
     /**
      * Create a new BuildStep middleware generator with the provided type name.
      *
-     * @param identifier is the type name to identify the middleware.
+     * @param name is the type name to identify the middleware.
+     * @param id   the unique ID for the middleware.
      * @return the middleware generator.
      */
-    public static GoStackStepMiddlewareGenerator createBuildStepMiddleware(String identifier) {
-        return createMiddleware(identifier,
+    public static GoStackStepMiddlewareGenerator createBuildStepMiddleware(String name, String id) {
+        return createMiddleware(name,
+                id,
                 "HandleBuild",
                 SymbolUtils.createValueSymbolBuilder("BuildInput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
                 SymbolUtils.createValueSymbolBuilder("BuildOutput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
@@ -78,11 +84,12 @@ public final class GoStackStepMiddlewareGenerator {
     /**
      * Create a new SerializeStep middleware generator with the provided type name.
      *
-     * @param identifier is the type name to identify the middleware.
+     * @param name is the type name to identify the middleware.
      * @return the middleware generator.
      */
-    public static GoStackStepMiddlewareGenerator createSerializeStepMiddleware(String identifier) {
-        return createMiddleware(identifier,
+    public static GoStackStepMiddlewareGenerator createSerializeStepMiddleware(String name, String id) {
+        return createMiddleware(name,
+                id,
                 "HandleSerialize",
                 SymbolUtils.createValueSymbolBuilder("SerializeInput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
                 SymbolUtils.createValueSymbolBuilder("SerializeOutput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
@@ -92,11 +99,12 @@ public final class GoStackStepMiddlewareGenerator {
     /**
      * Create a new DeserializeStep middleware generator with the provided type name.
      *
-     * @param identifier is the type name to identify the middleware.
+     * @param name is the type name to identify the middleware.
      * @return the middleware generator.
      */
-    public static GoStackStepMiddlewareGenerator createDeserializeStepMiddleware(String identifier) {
-        return createMiddleware(identifier,
+    public static GoStackStepMiddlewareGenerator createDeserializeStepMiddleware(String name, String id) {
+        return createMiddleware(name,
+                id,
                 "HandleDeserialize",
                 SymbolUtils.createValueSymbolBuilder("DeserializeInput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
                 SymbolUtils.createValueSymbolBuilder("DeserializeOutput", SmithyGoDependency.SMITHY_MIDDLEWARE).build(),
@@ -105,41 +113,26 @@ public final class GoStackStepMiddlewareGenerator {
     }
 
     /**
-     * Create a new InitializeStep middleware generator with the provided type name.
-     *
-     * @param identifier is the type name to identify the middleware.
-     * @return the middleware generator.
-     */
-    public static GoStackStepMiddlewareGenerator createInitializeStepMiddleware(String identifier) {
-        return createMiddleware(identifier,
-                "HandleInitialize",
-                SymbolUtils.createValueSymbolBuilder("InitializeInput", SmithyGoDependency.SMITHY_MIDDLEWARE)
-                        .build(),
-                SymbolUtils.createValueSymbolBuilder("InitializeOutput", SmithyGoDependency.SMITHY_MIDDLEWARE)
-                        .build(),
-                SymbolUtils.createValueSymbolBuilder("InitializeHandler", SmithyGoDependency.SMITHY_MIDDLEWARE)
-                        .build());
-    }
-
-    /**
      * Generates a new step middleware generator.
      *
-     * @param identifier        the name of the middleware type.
-     * @param handlerMethodName identifier method name to be implemented.
+     * @param name              the name of the middleware type.
+     * @param handlerMethodName method name to be implemented.
      * @param inputType         the middleware input type.
      * @param outputType        the middleware output type.
      * @param handlerType       the next handler type.
      * @return the middleware generator.
      */
     public static GoStackStepMiddlewareGenerator createMiddleware(
-            String identifier,
+            String name,
+            String id,
             String handlerMethodName,
             Symbol inputType,
             Symbol outputType,
             Symbol handlerType
     ) {
         return builder()
-                .identifier(identifier)
+                .name(name)
+                .id(id)
                 .handleMethodName(handlerMethodName)
                 .inputType(inputType)
                 .outputType(outputType)
@@ -199,7 +192,7 @@ public final class GoStackStepMiddlewareGenerator {
         // each middleware step has to implement the ID function and return a unique string to identify itself with
         // here we return the name of the type
         writer.openBlock("func ($P) ID() string {", "}", middlewareSymbol, () -> {
-            writer.openBlock("return $S", middlewareSymbol);
+            writer.openBlock("return $S", middlewareId);
         });
 
         writer.write("");
@@ -243,6 +236,15 @@ public final class GoStackStepMiddlewareGenerator {
      */
     public Symbol getMiddlewareSymbol() {
         return middlewareSymbol;
+    }
+
+    /**
+     * Get the id of the middleware.
+     *
+     * @return id for the middleware.
+     */
+    public String getMiddlewareId() {
+        return middlewareId;
     }
 
     /**
@@ -294,7 +296,8 @@ public final class GoStackStepMiddlewareGenerator {
      * Builds a {@link GoStackStepMiddlewareGenerator}.
      */
     public static class Builder {
-        private String identifier;
+        private String name;
+        private String id;
         private String handleMethodName;
         private Symbol inputType;
         private Symbol outputType;
@@ -321,13 +324,24 @@ public final class GoStackStepMiddlewareGenerator {
         }
 
         /**
-         * Set the identifier of the type to be generated.
+         * Set the name of the middleware type to be generated.
          *
-         * @param identifier the name to identify the middleware type.
+         * @param name the name of the middleware type.
          * @return the builder.
          */
-        public Builder identifier(String identifier) {
-            this.identifier = identifier;
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Set the id for the middleware to be generated.
+         *
+         * @param id the middleware stack identifier.
+         * @return the builder.
+         */
+        public Builder id(String id) {
+            this.id = id;
             return this;
         }
 
@@ -354,7 +368,7 @@ public final class GoStackStepMiddlewareGenerator {
         }
 
         /**
-         * Set the hander type symbol reference for the middleware.
+         * Set the handler type symbol reference for the middleware.
          *
          * @param handlerType the symbol reference to the handler type.
          * @return the builder.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -243,8 +243,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
     private void generateOperationSerializerMiddleware(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
-                ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()
-                ));
+                ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()),
+                "OperationSerializer"
+                );
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
@@ -339,7 +340,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     // output shapes for the operation.
     private void generateOperationDeserializerMiddleware(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createDeserializeStepMiddleware(
-                ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()));
+                ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()),
+                "OperationDeserializer"
+                );
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -58,6 +58,8 @@ import software.amazon.smithy.utils.OptionalUtils;
  * Abstract implementation useful for all protocols that use HTTP bindings.
  */
 public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator {
+    public static final String OPERATION_SERIALIZER_MIDDLEWARE_ID = "OperationSerializer";
+    public static final String OPERATION_DESERIALIZER_MIDDLEWARE_ID = "OperationDeserializer";
 
     private static final Logger LOGGER = Logger.getLogger(HttpBindingProtocolGenerator.class.getName());
 
@@ -244,7 +246,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateOperationSerializerMiddleware(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
                 ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), getProtocolName()),
-                "OperationSerializer"
+                OPERATION_SERIALIZER_MIDDLEWARE_ID
                 );
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
@@ -341,7 +343,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateOperationDeserializerMiddleware(GenerationContext context, OperationShape operation) {
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createDeserializeStepMiddleware(
                 ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), getProtocolName()),
-                "OperationDeserializer"
+                OPERATION_DESERIALIZER_MIDDLEWARE_ID
                 );
 
         SymbolProvider symbolProvider = context.getSymbolProvider();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -51,7 +51,9 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
     ) {
         GoStackStepMiddlewareGenerator middlewareGenerator =
                 GoStackStepMiddlewareGenerator.createInitializeStepMiddleware(
-                        getIdempotencyTokenMiddlewareName(operation));
+                        getIdempotencyTokenMiddlewareName(operation),
+                        "OperationIdempotencyTokenAutoFill"
+                        );
 
         Shape inputShape = model.expectShape(operation.getInput().get());
         Symbol inputSymbol = symbolProvider.toSymbol(inputShape);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -39,6 +39,7 @@ import software.amazon.smithy.utils.ListUtils;
 
 public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
     public static final String IDEMPOTENCY_CONFIG_NAME = "IdempotencyTokenProvider";
+    public static final String OPERATION_IDEMPOTENCY_TOKEN_MIDDLEWARE_ID = "OperationIdempotencyTokenAutoFill";
 
     List<RuntimeClientPlugin> runtimeClientPlugins = new ArrayList<>();
 
@@ -52,7 +53,7 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
         GoStackStepMiddlewareGenerator middlewareGenerator =
                 GoStackStepMiddlewareGenerator.createInitializeStepMiddleware(
                         getIdempotencyTokenMiddlewareName(operation),
-                        "OperationIdempotencyTokenAutoFill"
+                        OPERATION_IDEMPOTENCY_TOKEN_MIDDLEWARE_ID
                         );
 
         Shape inputShape = model.expectShape(operation.getInput().get());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
@@ -60,6 +60,8 @@ import software.amazon.smithy.utils.StringUtils;
  * Generates Go validation middleware and shape helpers.
  */
 public class ValidationGenerator implements GoIntegration {
+    public static final String OPERATION_INPUT_VALIDATION_MIDDLEWARE_ID = "OperationInputValidation";
+
     private final List<RuntimeClientPlugin> runtimeClientPlugins = new ArrayList<>();
 
     /**
@@ -96,7 +98,7 @@ public class ValidationGenerator implements GoIntegration {
         for (Map.Entry<Shape, OperationShape> entry : operationShapeMap.entrySet()) {
             GoStackStepMiddlewareGenerator generator = GoStackStepMiddlewareGenerator.createInitializeStepMiddleware(
                     getOperationValidationMiddlewareName(entry.getValue()),
-                    "OperationInputValidation"
+                    OPERATION_INPUT_VALIDATION_MIDDLEWARE_ID
                     );
             String helperName = getShapeValidationFunctionName(entry.getKey(), true);
             Symbol inputSymbol = symbolProvider.toSymbol(entry.getKey());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
@@ -94,8 +94,10 @@ public class ValidationGenerator implements GoIntegration {
             Map<Shape, OperationShape> operationShapeMap
     ) {
         for (Map.Entry<Shape, OperationShape> entry : operationShapeMap.entrySet()) {
-            GoStackStepMiddlewareGenerator generator = GoStackStepMiddlewareGenerator.createInitalizeStepMiddleware(
-                    getOperationValidationMiddlewareName(entry.getValue()));
+            GoStackStepMiddlewareGenerator generator = GoStackStepMiddlewareGenerator.createInitializeStepMiddleware(
+                    getOperationValidationMiddlewareName(entry.getValue()),
+                    "OperationInputValidation"
+                    );
             String helperName = getShapeValidationFunctionName(entry.getKey(), true);
             Symbol inputSymbol = symbolProvider.toSymbol(entry.getKey());
             generator.writeMiddleware(writer, (g, w) -> {

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGeneratorTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGeneratorTest.java
@@ -10,16 +10,18 @@ public class GoStackStepMiddlewareGeneratorTest {
     public void generatesSerializeMiddlewareDefinition() {
         GoWriter writer = new GoWriter("middlewaregentest");
 
-        GoStackStepMiddlewareGenerator.createSerializeStepMiddleware("someMiddlewareId")
+        GoStackStepMiddlewareGenerator.createSerializeStepMiddleware("someMiddleware", "some id")
                 .writeMiddleware(writer, (m, w) -> {
                     w.openBlock("return next.$L(ctx, in)", m.getHandleMethodName());
                 });
 
         String generated = writer.toString();
 
-        assertThat(generated, containsString("type someMiddlewareId struct {"));
-        assertThat(generated, containsString("func (*someMiddlewareId) ID() string {"));
-        assertThat(generated, containsString("func (m *someMiddlewareId) HandleSerialize(" +
+        System.out.println(generated);
+        assertThat(generated, containsString("type someMiddleware struct {"));
+        assertThat(generated, containsString("func (*someMiddleware) ID() string {"));
+        assertThat(generated, containsString("return \"some id\""));
+        assertThat(generated, containsString("func (m *someMiddleware) HandleSerialize(" +
                 "ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) ("));
         assertThat(generated, containsString("out middleware.SerializeOutput, metadata middleware.Metadata, err error,"));
         assertThat(generated, containsString("return next.HandleSerialize(ctx, in)"));


### PR DESCRIPTION
Updates the helpers for generating SDK middleware in a client package to separate the middleware name from the ID. The SDK generated middleware generic names were added.

This change does not create constants or other methods of organizing the IDs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
