### PR TITLE
`io`: adds Reset method to io ringbuffer

### DIFF
--- a/io/ringbuffer.go
+++ b/io/ringbuffer.go
@@ -70,3 +70,10 @@ func (r *RingBuffer) Read(p []byte) (int, error) {
 	}
 	return readCount, nil
 }
+
+// Reset resets the ring buffer.
+func (r *RingBuffer) Reset() {
+	*r = RingBuffer{
+		slice: r.slice,
+	}
+}

--- a/io/ringbuffer_test.go
+++ b/io/ringbuffer_test.go
@@ -348,7 +348,7 @@ func TestRingBuffer_Reset(t *testing.T) {
 	if e, a := 0, ringBuffer.end; e != a {
 		t.Errorf("expect default end to point to %v , got %v", e, a)
 	}
-	if e, a := 10, len(ringBuffer.slice); e!=a {
+	if e, a := 10, len(ringBuffer.slice); e != a {
 		t.Errorf("expect ringBuffer capacity to be %v, got %v", e, a)
 	}
 
@@ -361,6 +361,11 @@ func TestRingBuffer_Reset(t *testing.T) {
 	if ringBuffer.size == 0 {
 		t.Errorf("expected ringBuffer to not be empty")
 	}
+
+	// Here the ringBuffer length is 10; while written string is "someThing new";
+	// The initial characters are thus overwritten by the ringbuffer.
+	// Thus the ring Buffer if completely read will have "eThing new".
+	// Here readBuffer size is 5; thus first 5 character "eThin" is read.
 	if e, a := "eThin", string(readBuffer); !strings.EqualFold(e, a) {
 		t.Errorf("expected read string to be %s, got %s", e, a)
 	}
@@ -376,16 +381,16 @@ func TestRingBuffer_Reset(t *testing.T) {
 	if e, a := 0, ringBuffer.end; e != a {
 		t.Errorf("expect default end to point to %v , got %v", e, a)
 	}
-	if e, a := 10, len(ringBuffer.slice); e!=a {
+	if e, a := 10, len(ringBuffer.slice); e != a {
 		t.Errorf("expect ringBuffer capacity to be %v, got %v", e, a)
 	}
 
 	// reading reset ring buffer
-	readCount, _ :=ringBuffer.Read(readBuffer)
+	readCount, _ := ringBuffer.Read(readBuffer)
 	if ringBuffer.size != 0 {
 		t.Errorf("expected ringBuffer to be empty")
 	}
-	if e, a := 0, readCount ; e!=a {
+	if e, a := 0, readCount; e != a {
 		t.Errorf("expected read string to be of length %v, got %v", e, a)
 	}
 }

--- a/io/ringbuffer_test.go
+++ b/io/ringbuffer_test.go
@@ -318,3 +318,74 @@ func TestRingBuffer_ExhaustiveRead(t *testing.T) {
 		t.Errorf("Expected ring buffer size to be %v, got %v", e, a)
 	}
 }
+
+func TestRingBuffer_Reset(t *testing.T) {
+	byteSlice := make([]byte, 10)
+	ringBuffer := NewRingBuffer(byteSlice)
+
+	ringBuffer.Write([]byte("Hello-world"))
+	if ringBuffer.size == 0 {
+		t.Errorf("expected ringBuffer to not be empty")
+	}
+
+	readBuffer := make([]byte, 5)
+	ringBuffer.Read(readBuffer)
+	if ringBuffer.size == 0 {
+		t.Errorf("expected ringBuffer to not be empty")
+	}
+	if e, a := "ello-", string(readBuffer); !strings.EqualFold(e, a) {
+		t.Errorf("expected read string to be %s, got %s", e, a)
+	}
+
+	// reset the buffer
+	ringBuffer.Reset()
+	if e, a := 0, ringBuffer.size; e != a {
+		t.Errorf("expect default size to be %v , got %v", e, a)
+	}
+	if e, a := 0, ringBuffer.start; e != a {
+		t.Errorf("expect deafult start to point to %v , got %v", e, a)
+	}
+	if e, a := 0, ringBuffer.end; e != a {
+		t.Errorf("expect default end to point to %v , got %v", e, a)
+	}
+	if e, a := 10, len(ringBuffer.slice); e!=a {
+		t.Errorf("expect ringBuffer capacity to be %v, got %v", e, a)
+	}
+
+	ringBuffer.Write([]byte("someThing new"))
+	if ringBuffer.size == 0 {
+		t.Errorf("expected ringBuffer to not be empty")
+	}
+
+	ringBuffer.Read(readBuffer)
+	if ringBuffer.size == 0 {
+		t.Errorf("expected ringBuffer to not be empty")
+	}
+	if e, a := "eThin", string(readBuffer); !strings.EqualFold(e, a) {
+		t.Errorf("expected read string to be %s, got %s", e, a)
+	}
+
+	// reset the buffer
+	ringBuffer.Reset()
+	if e, a := 0, ringBuffer.size; e != a {
+		t.Errorf("expect default size to be %v , got %v", e, a)
+	}
+	if e, a := 0, ringBuffer.start; e != a {
+		t.Errorf("expect deafult start to point to %v , got %v", e, a)
+	}
+	if e, a := 0, ringBuffer.end; e != a {
+		t.Errorf("expect default end to point to %v , got %v", e, a)
+	}
+	if e, a := 10, len(ringBuffer.slice); e!=a {
+		t.Errorf("expect ringBuffer capacity to be %v, got %v", e, a)
+	}
+
+	// reading reset ring buffer
+	readCount, _ :=ringBuffer.Read(readBuffer)
+	if ringBuffer.size != 0 {
+		t.Errorf("expected ringBuffer to be empty")
+	}
+	if e, a := 0, readCount ; e!=a {
+		t.Errorf("expected read string to be of length %v, got %v", e, a)
+	}
+}


### PR DESCRIPTION
*Description of changes:*
	* Adds a Reset method to ring Buffer utility in `io` package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
