### PR TITLE
Fix protocol test generation for nested shape null values

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -66,6 +66,15 @@ public final class ShapeValueGenerator {
      * @param params parameters to fill the generated shape declaration.
      */
     public void writeShapeValueInline(GoWriter writer, Shape shape, Node params) {
+        if (params.isNullNode()) {
+            if (shape.isStringShape() && shape.hasTrait(EnumTrait.class)) {
+                writer.writeInline("\"\"");
+            } else {
+                writer.writeInline("nil");
+            }
+            return;
+        }
+
         switch (shape.getType()) {
             case STRUCTURE:
                 structDeclShapeValue(writer, shape.asStructureShape().get(), () -> {
@@ -88,19 +97,11 @@ public final class ShapeValueGenerator {
 
             case UNION:
             case DOCUMENT:
-                LOGGER.warning("Skipping " + shape.getType() + " shape type not suppported, " + shape.getId());
+                LOGGER.warning("Skipping " + shape.getType() + " shape type not supported, " + shape.getId());
                 writer.writeInline("nil");
                 break;
 
             default:
-                if (params.isNullNode()) {
-                    if (shape.isStringShape() && shape.hasTrait(EnumTrait.class)) {
-                        writer.writeInline("\"\"");
-                    } else {
-                        writer.writeInline("nil");
-                    }
-                    break;
-                }
 
                 scalarWrapShapeValue(writer, shape, () -> {
                     params.accept(new ShapeValueNodeVisitor(writer, this, shape));

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -68,7 +68,8 @@ public final class ShapeValueGenerator {
     public void writeShapeValueInline(GoWriter writer, Shape shape, Node params) {
         if (params.isNullNode()) {
             if (shape.isStringShape() && shape.hasTrait(EnumTrait.class)) {
-                writer.writeInline("\"\"");
+                Symbol enumSymbol = symbolProvider.toSymbol(shape);
+                writer.writeInline("$T($S)", enumSymbol, "");
             } else {
                 writer.writeInline("nil");
             }
@@ -180,10 +181,12 @@ public final class ShapeValueGenerator {
                 break;
 
             case STRING:
-                // Enum are not pointers, but values
+                // Enum are not pointers, but string alias values
                 if (shape.hasTrait(EnumTrait.class)) {
-                    inner.run();
-                    return;
+                    Symbol enumSymbol = symbolProvider.toSymbol(shape);
+                    writer.writeInline("$T(", enumSymbol);
+                    withPtrImport = false;
+                    break;
                 }
 
                 writer.writeInline("ptr.String(");
@@ -340,7 +343,8 @@ public final class ShapeValueGenerator {
         @Override
         public Void nullNode(NullNode node) {
             if (currentShape.getType() == ShapeType.STRING && currentShape.hasTrait(EnumTrait.class)) {
-                writer.writeInline("\"\"");
+                Symbol enumSymbol = symbolProvider.toSymbol(currentShape);
+                writer.writeInline("$T($S)", enumSymbol, "");
             } else {
                 writer.writeInline("nil");
             }
@@ -397,7 +401,6 @@ public final class ShapeValueGenerator {
             switch (currentShape.getType()) {
                 case BLOB:
                 case STRING:
-                    // TODO it would be nice if this used the enum const name instead of the literal string enum value.
                     writer.writeInline("$S", node.getValue());
                     break;
 


### PR DESCRIPTION
Fixes the generated protocol tests to correctly generate Go type values for shapes nested within nested list, structs, and maps. The generation was incorrectly initializing the nested shape, before assigning in inner value of nil.

Example codegen diff

```diff
--- a/internal/protocoltest/awsrestjson/api_op_JsonMaps_test.go
+++ b/internal/protocoltest/awsrestjson/api_op_JsonMaps_test.go
@@ -70,8 +70,7 @@ func TestClient_JsonMaps_awsRestjson1Serialize(t *testing.T) {
                "RestJsonSerializesNullMapValues": {
                        Params: &JsonMapsInput{
                                MyMap: map[string]*types.GreetingStruct{
-                                       "foo": {
-                                               nil},
+                                       "foo": nil,
                                },
                        },
                        ExpectMethod:  "POST",
@@ -206,8 +205,7 @@ func TestClient_JsonMaps_awsRestjson1Deserialize(t *testing.T) {
                        }`),
                        ExpectResult: &JsonMapsOutput{
                                MyMap: map[string]*types.GreetingStruct{
-                                       "foo": {
-                                               nil},
+                                       "foo": nil,
                                },
                        },
                },
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
