### PR TITLE
Allow not referencing rpc input

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -115,7 +115,11 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                 writer.write("return out, metadata, "
                         + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
                         + " in.Parameters)}");
-            }).write("");
+            });
+
+            // Allow for not handling the input if, for instance, the input has no members.
+            writer.write("_ = input");
+            writer.write("");
 
             writer.write("request.Request.URL.Path = $S", getOperationPath(context, operation));
             writer.write("request.Request.Method = \"POST\"");


### PR DESCRIPTION
This is to enable, for instance, an empty json body

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
