### PR TITLE
Update smithy-go Module dependency

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -96,6 +96,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200702221640-b1c2d4088d13";
+        private static final String SMITHY_GO = "v0.0.0-20200715183807-623301001f0d";
     }
 }


### PR DESCRIPTION
Updates the smithy-go Go module dependency hash to be the latest version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
