### PR TITLE
Refactor http binding protocol generator

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -132,10 +132,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      */
     protected abstract String getDocumentContentType();
 
-    private void generateOperationSerializer(
-            GenerationContext context,
-            OperationShape operation
-    ) {
+    private void generateOperationSerializer(GenerationContext context, OperationShape operation) {
         generateOperationSerializerMiddleware(context, operation);
         generateOperationHttpBindingSerializer(context, operation);
         generateOperationDocumentSerializer(context, operation);
@@ -248,13 +245,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             if (hasDocumentBindings) {
                 // delegate the setup and usage of the document serializer function for the protocol
-                writeMiddlewareDocumentSerializerDelegator(model, symbolProvider, operation, generator, writer);
+                writeMiddlewareDocumentSerializerDelegator(context, operation, generator);
 
             } else if (payloadBinding.isPresent()) {
                 // delegate the setup and usage of the payload serializer function for the protocol
                 MemberShape memberShape = payloadBinding.get().getMember();
-                writeMiddlewarePayloadSerializerDelegator(model, symbolProvider, operation, memberShape, generator,
-                        writer);
+                writeMiddlewarePayloadSerializerDelegator(context, operation, memberShape, generator);
             }
 
             writer.write("");
@@ -298,7 +294,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("");
 
             // Error shape middleware generation
-            writeMiddlewareErrorDeserializer(writer, model, symbolProvider, operation, generator);
+            writeMiddlewareErrorDeserializer(context, operation, generator);
 
             Shape outputShape = model.expectShape(operation.getOutput()
                     .orElseThrow(() -> new CodegenException("expect output shape for operation: " + operation.getId()))
@@ -328,7 +324,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Output Shape Document Binding middleware generation
             if (isShapeWithResponseBindings(model, operation, HttpBinding.Location.DOCUMENT)
                     || isShapeWithResponseBindings(model, operation, HttpBinding.Location.PAYLOAD)) {
-                writeMiddlewareDocumentDeserializerDelegator(writer, model, symbolProvider, operation, generator);
+                writeMiddlewareDocumentDeserializerDelegator(context, operation, generator);
                 writer.write("");
             }
 
@@ -340,52 +336,40 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the document serializer logic for the serializer middleware body.
      *
-     * @param model          the model
-     * @param symbolProvider the symbol provider
+     * @param context the generation context
      * @param operation      the operation
      * @param generator      middleware generator definition
-     * @param writer         the writer within the middlware context
      */
     protected abstract void writeMiddlewareDocumentSerializerDelegator(
-            Model model,
-            SymbolProvider symbolProvider,
+            GenerationContext context,
             OperationShape operation,
-            GoStackStepMiddlewareGenerator generator,
-            GoWriter writer
+            GoStackStepMiddlewareGenerator generator
     );
 
     /**
      * Generate the payload serializer logic for the serializer middleware body.
      *
-     * @param model          the model
-     * @param symbolProvider the symbol provider
+     * @param context the generation context
      * @param operation      the operation
      * @param memberShape    the payload target member
      * @param generator      middleware generator definition
-     * @param writer         the writer within the middlware context
      */
     protected abstract void writeMiddlewarePayloadSerializerDelegator(
-            Model model,
-            SymbolProvider symbolProvider,
+            GenerationContext context,
             OperationShape operation,
             MemberShape memberShape,
-            GoStackStepMiddlewareGenerator generator,
-            GoWriter writer
+            GoStackStepMiddlewareGenerator generator
     );
 
     /**
      * Generate the document deserializer logic for the deserializer middleware body.
      *
-     * @param writer         the writer within the middleware context
-     * @param model          the model
-     * @param symbolProvider the symbol provider
+     * @param context the generation context
      * @param operation      the operation
      * @param generator      middleware generator definition
      */
     protected abstract void writeMiddlewareDocumentDeserializerDelegator(
-            GoWriter writer,
-            Model model,
-            SymbolProvider symbolProvider,
+            GenerationContext context,
             OperationShape operation,
             GoStackStepMiddlewareGenerator generator
     );
@@ -394,20 +378,15 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the document deserializer logic for the deserializer middleware body.
      *
-     * @param model          the model
-     * @param symbolProvider the symbol provider
+     * @param context the generation context
      * @param operation      the operation
      * @param generator      middleware generator definition
-     * @param writer         the writer within the middleware context
      */
-    protected void writeMiddlewareErrorDeserializer(
-            GoWriter writer,
-            Model model,
-            SymbolProvider symbolProvider,
+    protected abstract void writeMiddlewareErrorDeserializer(
+            GenerationContext context,
             OperationShape operation,
             GoStackStepMiddlewareGenerator generator
-    ) {
-    }
+    );
 
     private boolean isRestBinding(HttpBinding.Location location) {
         return location == HttpBinding.Location.HEADER
@@ -471,10 +450,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         return false;
     }
 
-    private void generateOperationHttpBindingSerializer(
-            GenerationContext context,
-            OperationShape operation
-    ) {
+    private void generateOperationHttpBindingSerializer(GenerationContext context, OperationShape operation) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
         GoWriter writer = context.getWriter();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -17,16 +17,21 @@ package software.amazon.smithy.go.codegen.integration;
 
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.CodegenUtils;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.neighbor.RelationshipType;
 import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.utils.SetUtils;
 
 /**
@@ -116,5 +121,43 @@ public final class ProtocolUtils {
         return model.getKnowledge(OperationIndex.class).getOutput(operation)
                 .orElseThrow(() -> new CodegenException(
                         "Expected output shape for operation " + operation.getId().toString()));
+    }
+
+    /**
+     * Safely accesses a given structure member.
+     *
+     * @param context The generation context.
+     * @param member The member being accessed.
+     * @param container The name that the structure is assigned to.
+     * @param consumer A string consumer that is given the snippet to access the member value.
+     */
+    public static void writeSafeMemberAccessor(
+            GenerationContext context,
+            MemberShape member,
+            String container,
+            Consumer<String> consumer
+    ) {
+        Model model = context.getModel();
+        Shape target = model.expectShape(member.getTarget());
+        String memberName = context.getSymbolProvider().toMemberName(member);
+        String operand = container + "." + memberName;
+
+        boolean enumShape = target.hasTrait(EnumTrait.class);
+
+        if (!enumShape && !CodegenUtils.isNilAssignableToShape(model, member)) {
+            consumer.accept(operand);
+            return;
+        }
+
+        String conditionCheck;
+        if (enumShape) {
+            conditionCheck = "len(" + operand + ") > 0";
+        } else {
+            conditionCheck = operand + " != nil";
+        }
+
+        context.getWriter().openBlock("if $L {", "}", conditionCheck, () -> {
+            consumer.accept(operand);
+        });
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -70,7 +70,7 @@ public final class ProtocolUtils {
                         if (processed.contains(walkedShape.getId())) {
                             return;
                         }
-                        if (REQUIRES_SERDE.contains(walkedShape.getType())) {
+                        if (requiresDocumentSerdeFunction(shape)) {
                             resolvedShapes.add(walkedShape);
                             processed.add(walkedShape.getId());
                         }
@@ -78,6 +78,18 @@ public final class ProtocolUtils {
         });
 
         return resolvedShapes;
+    }
+
+    /**
+     * Determines whether a document serde function is required for the given shape.
+     *
+     * The following shape types will require a serde function: maps, lists, sets, documents, structures, and unions.
+     *
+     * @param shape the shape
+     * @return true if the shape requires a serde function
+     */
+    public static boolean requiresDocumentSerdeFunction(Shape shape) {
+        return REQUIRES_SERDE.contains(shape.getType());
     }
 
     /**


### PR DESCRIPTION
This refactors the rest protocol generator to use more of the shared code, notably error deserialization. It also updates the abstract methods to take `GenerationContext` where appropriate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

related: https://github.com/aws/aws-sdk-go-v2/pull/644