### PR TITLE
Implement URLFormEqual

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -60,7 +60,6 @@ public final class HttpProtocolGeneratorUtils {
         writer.openBlock("func $L(response $P) error {", "}", errorFunctionName, responseType, () -> {
             writer.addUseImports(SmithyGoDependency.BYTES);
             writer.addUseImports(SmithyGoDependency.IO);
-            writer.addUseImports(SmithyGoDependency.SMITHY_IO);
             writer.write("defer response.Body.Close()");
             writer.write("");
 

--- a/testing/document.go
+++ b/testing/document.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -65,7 +66,21 @@ func AssertXMLEqual(t T, expect, actual []byte) bool {
 // contain the same values. Returns an error if the two documents are not
 // equal.
 func URLFormEqual(expectBytes, actualBytes []byte) error {
-	return fmt.Errorf("URLFormEqual not implemented")
+	expected, err := url.ParseQuery(string(expectBytes))
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal expected bytes, %v", err)
+	}
+
+	actual, err := url.ParseQuery(string(actualBytes))
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal actual bytes, %v", err)
+	}
+
+	if diff := cmp.Diff(expected, actual); len(diff) != 0 {
+		return fmt.Errorf("Query mismatch (-expect +actual):\n%s", diff)
+	}
+
+	return nil
 }
 
 // AssertURLFormEqual compares two URLForm documents and identifies if the

--- a/testing/document_test.go
+++ b/testing/document_test.go
@@ -34,3 +34,34 @@ func TestAssertJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestAssertURLFormEqual(t *testing.T) {
+	cases := map[string]struct {
+		X, Y  []byte
+		Equal bool
+	}{
+		"equal": {
+			X:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo&MapArg.entry.2.key=bar&MapArg.entry.2.value=Bar`),
+			Y:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.2.key=bar&MapArg.entry.2.value=Bar&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo`),
+			Equal: true,
+		},
+		"not equal": {
+			X:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo&MapArg.entry.2.key=bar&MapArg.entry.2.value=Bar`),
+			Y:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo`),
+			Equal: false,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := URLFormEqual(c.X, c.Y)
+			if c.Equal {
+				if err != nil {
+					t.Fatalf("expect form to be equal, %v", err)
+				}
+			} else if err == nil {
+				t.Fatalf("expect form to be equal, %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements `URLFormEqual`, which is needed to run protocol tests for query. I also slipped in a minor change to the shared http error gen to not import smithyio since it isn't used there.

It's a flat comparison, so things like Query's maps are flattened out, but the output is still useful:

```
=== RUN   TestAssertURLFormEqual/not_equal
    TestAssertURLFormEqual/not_equal: document_test.go:60: expect form to be equal, Query mismatch (-expect +actual):
          url.Values{
          	"Action":               {"QueryMaps"},
          	"MapArg.entry.1.key":   {"foo"},
          	"MapArg.entry.1.value": {"Foo"},
        - 	"MapArg.entry.2.key":   {"bar"},
        - 	"MapArg.entry.2.value": {"Bar"},
          	"Version":              {"2020-01-08"},
          }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
