### PR TITLE
Strip insignificant whitespace from form bodies and export NewQueryValue

### DIFF
--- a/httpbinding/encode.go
+++ b/httpbinding/encode.go
@@ -78,10 +78,10 @@ func (e *Encoder) SetURI(key string) URIValue {
 
 // SetQuery returns a QueryValue used for setting the given query key
 func (e *Encoder) SetQuery(key string) QueryValue {
-	return newQueryValue(e.query, key, false)
+	return NewQueryValue(e.query, key, false)
 }
 
 // AddQuery returns a QueryValue used for appending the given query key
 func (e *Encoder) AddQuery(key string) QueryValue {
-	return newQueryValue(e.query, key, true)
+	return NewQueryValue(e.query, key, true)
 }

--- a/httpbinding/query.go
+++ b/httpbinding/query.go
@@ -14,7 +14,7 @@ type QueryValue struct {
 	append bool
 }
 
-func newQueryValue(query url.Values, key string, append bool) QueryValue {
+func NewQueryValue(query url.Values, key string, append bool) QueryValue {
 	return QueryValue{
 		query:  query,
 		key:    key,

--- a/httpbinding/query.go
+++ b/httpbinding/query.go
@@ -14,6 +14,8 @@ type QueryValue struct {
 	append bool
 }
 
+// NewQueryValue creates a new QueryValue which enables encoding
+// a query value into the given url.Values.
 func NewQueryValue(query url.Values, key string, append bool) QueryValue {
 	return QueryValue{
 		query:  query,

--- a/httpbinding/query_test.go
+++ b/httpbinding/query_test.go
@@ -189,7 +189,7 @@ func TestQueryValue(t *testing.T) {
 				tt.values = url.Values{}
 			}
 
-			qv := newQueryValue(tt.values, queryKey, tt.append)
+			qv := NewQueryValue(tt.values, queryKey, tt.append)
 
 			if err := setQueryValue(qv, tt.args); err != nil {
 				t.Fatalf("expected no error, got %v", err)

--- a/testing/document_test.go
+++ b/testing/document_test.go
@@ -45,6 +45,23 @@ func TestAssertURLFormEqual(t *testing.T) {
 			Y:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.2.key=bar&MapArg.entry.2.value=Bar&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo`),
 			Equal: true,
 		},
+		"strips insignificant whitespace": {
+			X: []byte(`Foo=Bar   &Baz=Bar
+					&Bin=Foo`),
+			Y:     []byte(`Foo=Bar&Baz=Bar&Bin=Foo`),
+			Equal: true,
+		},
+		"preserves significant whitespace": {
+			X:     []byte(`Foo=Bar+&Baz=Bar%20&Bin=Foo%0A`),
+			Y:     []byte(`Foo=Bar%20&Baz=Bar+&Bin=Foo%0A`),
+			Equal: true,
+		},
+		"missing significant whitespace not equal": {
+			X: []byte(`Foo=Bar+&Baz=Bar%20&Bin=Foo%0A%09%09%09%09&Spam=Eggs`),
+			Y: []byte(`Foo=Bar &Baz=Bar &Bin=Foo
+				&Spam=Eggs`),
+			Equal: false,
+		},
 		"not equal": {
 			X:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo&MapArg.entry.2.key=bar&MapArg.entry.2.value=Bar`),
 			Y:     []byte(`Action=QueryMaps&Version=2020-01-08&MapArg.entry.1.key=foo&MapArg.entry.1.value=Foo`),


### PR DESCRIPTION
This updates the url form equal function to strip out insignificant whitespace, which is whitespace that is not percent encoded.

I've also updated `NewQueryValue` to be exported so it can be used in the query serializer.

Needed for: https://github.com/aws/aws-sdk-go-v2/pull/652

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
