### PR TITLE
add xml encoder, assert-xml util for xml document serialization

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -50,6 +50,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_PTR = smithy("ptr");
     public static final GoDependency SMITHY_RAND = smithy("rand", "smithyrand");
     public static final GoDependency SMITHY_TESTING = smithy("testing", "smithytesting");
+    public static final GoDependency SMITHY_XML = smithy("xml", "smithyxml");
 
     public static final GoDependency GO_CMP = goCmp("cmp");
     public static final GoDependency GO_CMP_OPTIONS = goCmp("cmp/cmpopts");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -108,6 +108,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200819234259-983434bb17eb";
+        private static final String SMITHY_GO = "v0.0.0-20200820043901-ef309bba027a";
     }
 }

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -1,0 +1,40 @@
+package encoding
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// EncodeFloat encodes a float value as per the stdlib encoder for json and xml protocol
+// This encodes a float value into dst while attempting to conform to ES6 ToString for Numbers
+//
+// Based on encoding/json floatEncoder from the Go Standard Library
+// https://golang.org/src/encoding/json/encode.go
+func EncodeFloat(dst []byte, v float64, bits int) []byte {
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		panic(fmt.Sprintf("invalid float value: %s", strconv.FormatFloat(v, 'g', -1, bits)))
+	}
+
+	abs := math.Abs(v)
+	fmt := byte('f')
+
+	if abs != 0 {
+		if bits == 64 && (abs < 1e-6 || abs >= 1e21) || bits == 32 && (float32(abs) < 1e-6 || float32(abs) >= 1e21) {
+			fmt = 'e'
+		}
+	}
+
+	dst = strconv.AppendFloat(dst, v, fmt, -1, bits)
+
+	if fmt == 'e' {
+		// clean up e-09 to e-9
+		n := len(dst)
+		if n >= 4 && dst[n-4] == 'e' && dst[n-3] == '-' && dst[n-2] == '0' {
+			dst[n-2] = dst[n-1]
+			dst = dst[:n-1]
+		}
+	}
+
+	return dst
+}

--- a/json/value.go
+++ b/json/value.go
@@ -3,10 +3,10 @@ package json
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
-	"math"
 	"math/big"
 	"strconv"
+
+	"github.com/awslabs/smithy-go/internal/encoding"
 )
 
 // Value represents a JSON Value type
@@ -58,7 +58,7 @@ func (jv Value) Double(v float64) {
 }
 
 func (jv Value) float(v float64, bits int) {
-	*jv.scratch = encodeFloat((*jv.scratch)[:0], v, bits)
+	*jv.scratch = encoding.EncodeFloat((*jv.scratch)[:0], v, bits)
 	jv.w.Write(*jv.scratch)
 }
 
@@ -106,38 +106,6 @@ func (jv Value) BigDecimal(v *big.Float) {
 	}
 	// TODO: Should this try to match ES6 ToString similar to stdlib JSON?
 	jv.w.Write([]byte(v.Text('e', -1)))
-}
-
-// Encodes a float value into dst while attempting to conform to ES6 ToString for Numbers
-//
-// Based on encoding/json floatEncoder from the Go Standard Library
-// https://golang.org/src/encoding/json/encode.go
-func encodeFloat(dst []byte, v float64, bits int) []byte {
-	if math.IsInf(v, 0) || math.IsNaN(v) {
-		panic(fmt.Sprintf("invalid float value: %s", strconv.FormatFloat(v, 'g', -1, bits)))
-	}
-
-	abs := math.Abs(v)
-	fmt := byte('f')
-
-	if abs != 0 {
-		if bits == 64 && (abs < 1e-6 || abs >= 1e21) || bits == 32 && (float32(abs) < 1e-6 || float32(abs) >= 1e21) {
-			fmt = 'e'
-		}
-	}
-
-	dst = strconv.AppendFloat(dst, v, fmt, -1, bits)
-
-	if fmt == 'e' {
-		// clean up e-09 to e-9
-		n := len(dst)
-		if n >= 4 && dst[n-4] == 'e' && dst[n-3] == '-' && dst[n-2] == '0' {
-			dst[n-2] = dst[n-1]
-			dst = dst[:n-1]
-		}
-	}
-
-	return dst
 }
 
 // Based on encoding/json encodeByteSlice from the Go Standard Library

--- a/testing/bytes.go
+++ b/testing/bytes.go
@@ -60,20 +60,19 @@ func CompareJSONReaderBytes(r io.Reader, expect []byte) error {
 	return nil
 }
 
-// CompareXMLReaderBytes compares the reader containing serialized XML
-// document. Deserializes the XML documents to determine if they are equal.
-// Return an error if the two XML documents are not equal.
+// CompareXMLReaderBytes compares the reader with expected xml byte
 func CompareXMLReaderBytes(r io.Reader, expect []byte) error {
 	if r == nil {
 		return fmt.Errorf("missing body")
 	}
+
 	actual, err := ioutil.ReadAll(r)
 	if err != nil {
-		return fmt.Errorf("unable to read, %v", err)
+		return err
 	}
 
 	if err := XMLEqual(expect, actual); err != nil {
-		return fmt.Errorf("XML documents not equal, %v", err)
+		return fmt.Errorf("XML documents not equal, %w", err)
 	}
 	return nil
 }

--- a/testing/document.go
+++ b/testing/document.go
@@ -1,11 +1,15 @@
 package testing
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"sort"
 	"strings"
+
+	"github.com/awslabs/smithy-go/testing/xml"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // JSONEqual compares two JSON documents and identifies if the documents contain
@@ -42,10 +46,25 @@ func AssertJSONEqual(t T, expect, actual []byte) bool {
 	return true
 }
 
-// XMLEqual compares two XML documents and identifies if the documents contain
-// the same values. Returns an error if the two documents are not equal.
+// XMLEqual asserts two xml documents by sorting the XML and comparing the strings
+// It returns an error in case of mismatch or in case of malformed xml found while sorting.
+// In case of mismatched XML, the error string will contain the diff between the two XMLs.
 func XMLEqual(expectBytes, actualBytes []byte) error {
-	return fmt.Errorf("XMLEqual not implemented")
+	actualString, err := xml.SortXML(bytes.NewBuffer(actualBytes), true)
+	if err != nil {
+		return err
+	}
+
+	expectedString, err := xml.SortXML(bytes.NewBuffer(expectBytes), true)
+	if err != nil {
+		return err
+	}
+
+	if diff := cmp.Diff(actualString, expectedString); len(diff) != 0 {
+		return fmt.Errorf("XML mismatch (-expect +actual):\n%s", diff)
+	}
+
+	return nil
 }
 
 // AssertXMLEqual compares two XML documents and identifies if the documents

--- a/testing/document_test.go
+++ b/testing/document_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -78,6 +79,155 @@ func TestAssertURLFormEqual(t *testing.T) {
 				}
 			} else if err == nil {
 				t.Fatalf("expect form to be equal, %v", err)
+			}
+		})
+	}
+}
+
+func TestEqualXMLUtil(t *testing.T) {
+	cases := map[string]struct {
+		expectedXML string
+		actualXML   string
+		expectErr   string
+	}{
+		"empty": {
+			expectedXML: ``,
+			actualXML:   ``,
+		},
+		"emptyWithDiff": {
+			expectedXML: ``,
+			actualXML:   `<Root></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"simpleXML": {
+			expectedXML: `<Root></Root>`,
+			actualXML:   `<Root></Root>`,
+		},
+		"simpleXMLWithDiff": {
+			expectedXML: `<Root></Root>`,
+			actualXML:   `<Root>abc</Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"nestedXML": {
+			expectedXML: `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+			actualXML:   `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+		},
+		"nestedXMLWithExpectedDiff": {
+			expectedXML: `<Root><abc>123</abc><cde>xyz</cde><pqr>234</pqr></Root>`,
+			actualXML:   `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"nestedXMLWithActualDiff": {
+			expectedXML: `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+			actualXML:   `<Root><abc>123</abc><cde>xyz</cde><pqr>234</pqr></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"Array": {
+			expectedXML: `<Root><list><member><nested>xyz</nested></member><member><nested>abc</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>abc</nested></member></list></Root>`,
+		},
+		"ArrayWithSecondDiff": {
+			expectedXML: `<Root><list><member><nested>xyz</nested></member><member><nested>123</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>345</nested></member></list></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"ArrayWithFirstDiff": {
+			expectedXML: `<Root><list><member><nested>abc</nested></member><member><nested>345</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>345</nested></member></list></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"ArrayWithMixedDiff": {
+			expectedXML: `<Root><list><member><nested>345</nested></member><member><nested>xyz</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>345</nested></member></list></Root>`,
+		},
+		"ArrayWithRepetitiveMembers": {
+			expectedXML: `<Root><list><member><nested>xyz</nested></member><member><nested>xyz</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>xyz</nested></member></list></Root>`,
+		},
+		"Map": {
+			expectedXML: `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+		},
+		"MapWithFirstDiff": {
+			expectedXML: `<Root><map><entry><key>bcf</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MapWithSecondDiff": {
+			expectedXML: `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>abc</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MapWithMixedDiff": {
+			expectedXML: `<Root><map><entry><key>cde</key><value>356</value></entry><entry><key>abc</key><value>123</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+		},
+		"MismatchCheckforKeyValue": {
+			expectedXML: `<Root><map><entry><key>cde</key><value>abc</value></entry><entry><key>abc</key><value>356</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MixMapAndListNestedXML": {
+			expectedXML: `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+		},
+		"MixMapAndListNestedXMLWithDiff": {
+			expectedXML: `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><beta><x>gamma</x></beta></nested></v></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"xmlWithNamespaceAndAttr": {
+			expectedXML: `<Root xmlns:ab="https://example.com" attr="apple">value</Root>`,
+			actualXML:   `<Root xmlns:ab="https://example.com" attr="apple">value</Root>`,
+		},
+		"xmlUnorderedAttributes": {
+			expectedXML: `<Root atr="banana" attrNew="apple">v</Root>`,
+			actualXML:   `<Root attrNew="apple" atr="banana">v</Root>`,
+		},
+		"xmlAttributesWithDiff": {
+			expectedXML: `<Root atr="someAtr" attrNew="apple">v</Root>`,
+			actualXML:   `<Root attrNew="apple" atr="banana">v</Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"xmlUnorderedNamespaces": {
+			expectedXML: `<Root xmlns:ab="https://example.com" xmlns:baz="https://example2.com">v</Root>`,
+			actualXML:   `<Root xmlns:baz="https://example2.com" xmlns:ab="https://example.com">v</Root>`,
+		},
+		"xmlNamespaceWithDiff": {
+			expectedXML: `<Root xmlns:ab="https://example-diff.com" xmlns:baz="https://example2.com">v</Root>`,
+			actualXML:   `<Root xmlns:baz="https://example2.com" xmlns:ab="https://example.com">v</Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"NestedWithNamespaceAndAttributes": {
+			expectedXML: `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><ab:list>mem1</ab:list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><ab:list>mem1</ab:list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+		},
+		"NestedWithNamespaceAndAttributesWithDiff": {
+			expectedXML: `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><list>mem2</list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><list>mem1</list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MalformedXML": {
+			expectedXML: `<Root><fmap><key>a</key><key2>a2</key2><value>v</value></fmap><fmap><key>b</key><key2>b2</key2><value>w</value></fmap></Root>`,
+			actualXML:   `<Root><fmap><key>a</key><key2>a2</key2><value>v</value></fmap><fmap><key>b</key><key2>b2</key2><value>w</value></fmap></Root>`,
+			expectErr:   "malformed xml",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := []byte(c.actualXML)
+			expected := []byte(c.expectedXML)
+
+			err := XMLEqual(actual, expected)
+			if err != nil {
+				if len(c.expectErr) == 0 {
+					t.Fatalf("expected no error while parsing xml, got %v", err)
+				} else if !strings.Contains(err.Error(), c.expectErr) {
+					t.Fatalf("expected expected XML err to contain %s, got %s", c.expectErr, err.Error())
+				}
+			} else if len(c.expectErr) != 0 {
+				t.Fatalf("expected error %s, got none", c.expectErr)
 			}
 		})
 	}

--- a/testing/xml/doc.go
+++ b/testing/xml/doc.go
@@ -1,0 +1,6 @@
+// package xml is xml testing package that supports xml comparison utility.
+// The package consists of XMLToStruct and StructToXML utils that help sort xml elements
+// as per their nesting level. XMLToStruct function converts an xml document into a sorted
+// tree node structure, while StructToXML converts the sorted xml nodes into a sorted xml document.
+// SortXML function should be used to sort an xml document. It can be configured to ignore indentation
+package xml

--- a/testing/xml/sort.go
+++ b/testing/xml/sort.go
@@ -1,0 +1,48 @@
+package xml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"strings"
+)
+
+type xmlAttrSlice []xml.Attr
+
+func (x xmlAttrSlice) Len() int {
+	return len(x)
+}
+
+func (x xmlAttrSlice) Less(i, j int) bool {
+	spaceI, spaceJ := x[i].Name.Space, x[j].Name.Space
+	localI, localJ := x[i].Name.Local, x[j].Name.Local
+	valueI, valueJ := x[i].Value, x[j].Value
+
+	spaceCmp := strings.Compare(spaceI, spaceJ)
+	localCmp := strings.Compare(localI, localJ)
+	valueCmp := strings.Compare(valueI, valueJ)
+
+	if spaceCmp == -1 || (spaceCmp == 0 && (localCmp == -1 || (localCmp == 0 && valueCmp == -1))) {
+		return true
+	}
+
+	return false
+}
+
+func (x xmlAttrSlice) Swap(i, j int) {
+	x[i], x[j] = x[j], x[i]
+}
+
+// SortXML sorts the reader's XML elements
+func SortXML(r io.Reader, ignoreIndentation bool) (string, error) {
+	var buf bytes.Buffer
+	d := xml.NewDecoder(r)
+	root, err := XMLToStruct(d, nil, ignoreIndentation)
+	if err != nil {
+		return buf.String(), err
+	}
+
+	e := xml.NewEncoder(&buf)
+	err = StructToXML(e, root, true)
+	return buf.String(), err
+}

--- a/testing/xml/sort_test.go
+++ b/testing/xml/sort_test.go
@@ -1,0 +1,21 @@
+package xml
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSortXML(t *testing.T) {
+	xmlInput := bytes.NewReader([]byte(`<Root><cde>xyz</cde><abc>123</abc><xyz><item>1</item></xyz></Root>`))
+	sortedXML, err := SortXML(xmlInput, false)
+	expectedsortedXML := `<Root><abc>123</abc><cde>xyz</cde><xyz><item>1</item></xyz></Root>`
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if diff := cmp.Diff(sortedXML, expectedsortedXML); len(diff) != 0 {
+		t.Fatalf("found diff: %v", diff)
+	}
+}

--- a/testing/xml/xmlToStruct.go
+++ b/testing/xml/xmlToStruct.go
@@ -1,0 +1,339 @@
+package xml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// A XMLNode contains the values to be encoded or decoded.
+type XMLNode struct {
+	Name     xml.Name              `json:",omitempty"`
+	Children map[string][]*XMLNode `json:",omitempty"`
+	Text     string                `json:",omitempty"`
+	Attr     []xml.Attr            `json:",omitempty"`
+
+	namespaces map[string]string
+	parent     *XMLNode
+}
+
+// NewXMLElement returns a pointer to a new XMLNode initialized to default values.
+func NewXMLElement(name xml.Name) *XMLNode {
+	return &XMLNode{
+		Name:     name,
+		Children: map[string][]*XMLNode{},
+		Attr:     []xml.Attr{},
+	}
+}
+
+// AddChild adds child to the XMLNode.
+func (n *XMLNode) AddChild(child *XMLNode) {
+	child.parent = n
+	if _, ok := n.Children[child.Name.Local]; !ok {
+		// flattened will have multiple children with same tag name
+		n.Children[child.Name.Local] = []*XMLNode{}
+	}
+	n.Children[child.Name.Local] = append(n.Children[child.Name.Local], child)
+}
+
+// XMLToStruct converts a xml.Decoder stream to XMLNode with nested values.
+func XMLToStruct(d *xml.Decoder, s *xml.StartElement, ignoreIndentation bool) (*XMLNode, error) {
+	out := &XMLNode{}
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return out, err
+			}
+		}
+
+		if tok == nil {
+			break
+		}
+
+		switch typed := tok.(type) {
+		case xml.CharData:
+			text := string(typed.Copy())
+			if ignoreIndentation {
+				text = strings.TrimSpace(text)
+			}
+			if len(text) != 0 {
+				out.Text = text
+			}
+		case xml.StartElement:
+			el := typed.Copy()
+			out.Attr = el.Attr
+			if out.Children == nil {
+				out.Children = map[string][]*XMLNode{}
+			}
+
+			name := typed.Name.Local
+			slice := out.Children[name]
+			if slice == nil {
+				slice = []*XMLNode{}
+			}
+			node, e := XMLToStruct(d, &el, ignoreIndentation)
+			out.findNamespaces()
+			if e != nil {
+				return out, e
+			}
+
+			node.Name = typed.Name
+			node.findNamespaces()
+
+			// Add attributes onto the node
+			node.Attr = el.Attr
+
+			tempOut := *out
+			// Save into a temp variable, simply because out gets squashed during
+			// loop iterations
+			node.parent = &tempOut
+			slice = append(slice, node)
+			out.Children[name] = slice
+		case xml.EndElement:
+			if s != nil && s.Name.Local == typed.Name.Local { // matching end token
+				return out, nil
+			}
+			out = &XMLNode{}
+		}
+	}
+	return out, nil
+}
+
+func (n *XMLNode) findNamespaces() {
+	ns := map[string]string{}
+	for _, a := range n.Attr {
+		if a.Name.Space == "xmlns" {
+			ns[a.Value] = a.Name.Local
+		}
+	}
+
+	n.namespaces = ns
+}
+
+func (n *XMLNode) findElem(name string) (string, bool) {
+	for node := n; node != nil; node = node.parent {
+		for _, a := range node.Attr {
+			namespace := a.Name.Space
+			if v, ok := node.namespaces[namespace]; ok {
+				namespace = v
+			}
+			if name == fmt.Sprintf("%s:%s", namespace, a.Name.Local) {
+				return a.Value, true
+			}
+		}
+	}
+	return "", false
+}
+
+// StructToXML writes an XMLNode to a xml.Encoder as tokens.
+func StructToXML(e *xml.Encoder, node *XMLNode, sorted bool) error {
+	var err error
+	// Sort Attributes
+	attrs := node.Attr
+	if sorted {
+		sortedAttrs := make([]xml.Attr, len(attrs))
+		for _, k := range node.Attr {
+			sortedAttrs = append(sortedAttrs, k)
+		}
+		sort.Sort(xmlAttrSlice(sortedAttrs))
+		attrs = sortedAttrs
+	}
+
+	st := xml.StartElement{Name: node.Name, Attr: attrs}
+	e.EncodeToken(st)
+	// return fmt.Errorf("encoder string : %s, %s, %s", node.Name.Local, node.Name.Space, st.Attr)
+
+	if node.Text != "" {
+		e.EncodeToken(xml.CharData([]byte(node.Text)))
+	} else if sorted {
+		sortedNames := []string{}
+		for k := range node.Children {
+			sortedNames = append(sortedNames, k)
+		}
+		sort.Strings(sortedNames)
+
+		for _, k := range sortedNames {
+			// we should sort the []*xml.Node for each key if len >1
+			flattenedNodes := node.Children[k]
+			// Meaning this has multiple nodes
+			if len(flattenedNodes) > 1 {
+				// sort flattened nodes
+				flattenedNodes, err = sortFlattenedNodes(flattenedNodes)
+				if err != nil {
+					return err
+				}
+			}
+
+			for _, v := range flattenedNodes {
+				err = StructToXML(e, v, sorted)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		for _, c := range node.Children {
+			for _, v := range c {
+				err = StructToXML(e, v, sorted)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	e.EncodeToken(xml.EndElement{Name: node.Name})
+	return e.Flush()
+}
+
+// sortFlattenedNodes sorts nodes with nodes having same element tag
+// but overall different values. The function will return list of pointer to
+// XMLNode and an error.
+//
+// Overall sort order is followed is:
+// Nodes with concrete value (no nested node as value) are given precedence
+// and are added to list after sorting them
+//
+// Next nested nodes within a flattened list are given precedence.
+//
+// Next nodes within a flattened map are sorted based on either key or value
+// which ever has lower value and then added to the global sorted list.
+// If value was initially chosen, but has nested nodes; key will be chosen as comparable
+// as it is unique and will always have concrete data ie. string.
+func sortFlattenedNodes(nodes []*XMLNode) ([]*XMLNode, error) {
+	var sortedNodes []*XMLNode
+
+	// concreteNodeMap stores concrete value associated with a list of nodes
+	// This is possible in case multiple members of a flatList has same values.
+	concreteNodeMap := make(map[string][]*XMLNode, 0)
+
+	// flatListNodeMap stores flat list or wrapped list members associated with a list of nodes
+	// This will have only flattened list with members that are Nodes and not concrete values.
+	flatListNodeMap := make(map[string][]*XMLNode, 0)
+
+	// flatMapNodeMap stores flat map or map entry members associated with a list of nodes
+	// This will have only flattened map concrete value members. It is possible to limit this
+	// to concrete value as map key is expected to be concrete.
+	flatMapNodeMap := make(map[string][]*XMLNode, 0)
+
+	// nodes with concrete value are prioritized and appended based on sorting order
+	sortedNodesWithConcreteValue := []string{}
+
+	// list with nested nodes are second in priority and appended based on sorting order
+	sortedNodesWithListValue := []string{}
+
+	// map are last in priority and appended based on sorting order
+	sortedNodesWithMapValue := []string{}
+
+	for _, node := range nodes {
+		// node has no children element, then we consider it as having concrete value
+		if len(node.Children) == 0 {
+			sortedNodesWithConcreteValue = append(sortedNodesWithConcreteValue, node.Text)
+			if v, ok := concreteNodeMap[node.Text]; ok {
+				concreteNodeMap[node.Text] = append(v, node)
+			} else {
+				concreteNodeMap[node.Text] = []*XMLNode{node}
+			}
+		}
+
+		// if node has a single child, then it is a flattened list node
+		if len(node.Children) == 1 {
+			for _, nestedNodes := range node.Children {
+				nestedNodeName := nestedNodes[0].Name.Local
+
+				// append to sorted node name for list value
+				sortedNodesWithListValue = append(sortedNodesWithListValue, nestedNodeName)
+
+				if v, ok := flatListNodeMap[nestedNodeName]; ok {
+					flatListNodeMap[nestedNodeName] = append(v, nestedNodes[0])
+				} else {
+					flatListNodeMap[nestedNodeName] = []*XMLNode{nestedNodes[0]}
+				}
+			}
+		}
+
+		// if node has two children, then it is a flattened map node
+		if len(node.Children) == 2 {
+			nestedPair := []*XMLNode{}
+			for _, k := range node.Children {
+				nestedPair = append(nestedPair, k[0])
+			}
+
+			comparableValues := []string{nestedPair[0].Name.Local, nestedPair[1].Name.Local}
+			sort.Strings(comparableValues)
+
+			comparableValue := comparableValues[0]
+			for _, nestedNode := range nestedPair {
+				if comparableValue == nestedNode.Name.Local && len(nestedNode.Children) != 0 {
+					// if value was selected and is nested node, skip it and use key instead
+					comparableValue = comparableValues[1]
+					continue
+				}
+
+				// now we are certain there is no nested node
+				if comparableValue == nestedNode.Name.Local {
+					// get chardata for comparison
+					comparableValue = nestedNode.Text
+					sortedNodesWithMapValue = append(sortedNodesWithMapValue, comparableValue)
+
+					if v, ok := flatMapNodeMap[comparableValue]; ok {
+						flatMapNodeMap[comparableValue] = append(v, node)
+					} else {
+						flatMapNodeMap[comparableValue] = []*XMLNode{node}
+					}
+					break
+				}
+			}
+		}
+
+		// we don't support multiple same name nodes in an xml doc except for in flattened maps, list.
+		if len(node.Children) > 2 {
+			return nodes, fmt.Errorf("malformed xml: multiple nodes with same key name exist, " +
+				"but are not associated with flattened maps (2 children) or list (0 or 1 child)")
+		}
+	}
+
+	// sort concrete value node name list and append corresponding nodes
+	// to sortedNodes
+	sort.Strings(sortedNodesWithConcreteValue)
+	for _, name := range sortedNodesWithConcreteValue {
+		for _, node := range concreteNodeMap[name] {
+			sortedNodes = append(sortedNodes, node)
+		}
+	}
+
+	// sort nested nodes with a list and append corresponding nodes
+	// to sortedNodes
+	sort.Strings(sortedNodesWithListValue)
+	for _, name := range sortedNodesWithListValue {
+		// if two nested nodes have same name, then sort them separately.
+		if len(flatListNodeMap[name]) > 1 {
+			// return nodes, fmt.Errorf("flat list node name are %s %v", flatListNodeMap[name][0].Name.Local, len(flatListNodeMap[name]))
+			nestedFlattenedList, err := sortFlattenedNodes(flatListNodeMap[name])
+			if err != nil {
+				return nodes, err
+			}
+			// append the identical but sorted nodes
+			for _, nestedNode := range nestedFlattenedList {
+				sortedNodes = append(sortedNodes, nestedNode)
+			}
+		} else {
+			// append the sorted nodes
+			sortedNodes = append(sortedNodes, flatListNodeMap[name][0])
+		}
+	}
+
+	// sorted nodes with a map and append corresponding nodes to sortedNodes
+	sort.Strings(sortedNodesWithMapValue)
+	for _, name := range sortedNodesWithMapValue {
+		sortedNodes = append(sortedNodes, flatMapNodeMap[name][0])
+	}
+
+	return sortedNodes, nil
+}

--- a/xml/array.go
+++ b/xml/array.go
@@ -1,0 +1,49 @@
+package xml
+
+// arrayMemberWrapper is the default member wrapper tag name for XML Array type
+var arrayMemberWrapper = StartElement{
+	Name: Name{Local: "member"},
+}
+
+// Array represents the encoding of a XML array type
+type Array struct {
+	w       writer
+	scratch *[]byte
+
+	// member start element is the array member wrapper start element
+	memberStartElement StartElement
+
+	// isFlattened indicates if the array is a flattened array.
+	isFlattened bool
+}
+
+// newArray returns an array encoder.
+// It also takes in the  member start element, array start element.
+// It takes in a isFlattened bool, indicating that an array is flattened array.
+//
+// A wrapped array ["value1", "value2"] is represented as
+// `<List><member>value1</member><member>value2</member></List>`.
+
+// A flattened array `someList: ["value1", "value2"]` is represented as
+// `<someList>value1</someList><someList>value2</someList>`.
+func newArray(w writer, scratch *[]byte, memberStartElement StartElement, arrayStartElement StartElement, isFlattened bool) *Array {
+	var memberWrapper = memberStartElement
+	if isFlattened {
+		memberWrapper = arrayStartElement
+	}
+
+	return &Array{
+		w:                  w,
+		scratch:            scratch,
+		memberStartElement: memberWrapper,
+		isFlattened:        isFlattened,
+	}
+}
+
+// Member adds a new member to the XML array.
+// It returns a Value encoder.
+func (a *Array) Member() Value {
+	v := newValue(a.w, a.scratch, a.memberStartElement)
+	v.isFlattened = a.isFlattened
+	return v
+}

--- a/xml/array_test.go
+++ b/xml/array_test.go
@@ -1,0 +1,52 @@
+package xml
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWrappedArray(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	root := StartElement{Name: Name{Local: "array"}}
+	a := newArray(buffer, &scratch, arrayMemberWrapper, root, false)
+	a.Member().String("bar")
+	a.Member().String("baz")
+
+	e := []byte(`<member>bar</member><member>baz</member>`)
+	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+}
+
+func TestWrappedArrayWithCustomName(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	root := StartElement{Name: Name{Local: "array"}}
+	item := StartElement{Name: Name{Local: "item"}}
+	a := newArray(buffer, &scratch, item, root, false)
+	a.Member().String("bar")
+	a.Member().String("baz")
+
+	e := []byte(`<item>bar</item><item>baz</item>`)
+	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+}
+
+func TestFlattenedArray(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	root := StartElement{Name: Name{Local: "array"}}
+	a := newArray(buffer, &scratch, arrayMemberWrapper, root, true)
+	a.Member().String("bar")
+	a.Member().String("bix")
+
+	e := []byte(`<array>bar</array><array>bix</array>`)
+	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+}

--- a/xml/constants.go
+++ b/xml/constants.go
@@ -1,0 +1,10 @@
+package xml
+
+const (
+	leftAngleBracket  = '<'
+	rightAngleBracket = '>'
+	forwardSlash      = '/'
+	colon             = ':'
+	equals            = '='
+	quote             = '"'
+)

--- a/xml/doc.go
+++ b/xml/doc.go
@@ -1,0 +1,49 @@
+/*
+Package xml holds the XMl encoder utility. This utility is written in accordance to our design to delegate to
+shape serializer function in which a xml.Value will be passed around.
+
+Resources followed: https://awslabs.github.io/smithy/1.0/spec/core/xml-traits.html#
+
+Member Element
+
+Member element should be used to encode xml shapes into xml elements except for flattened xml shapes. Member element
+write their own element start tag. These elements should always be closed.
+
+Flattened Element
+
+Flattened element should be used to encode shapes marked with flattened trait into xml elements. Flattened element
+do not write a start tag, and thus should not be closed.
+
+Simple types encoding
+
+All simple type methods on value such as String(), Long() etc; auto close the associated member element.
+
+Array
+
+Array returns the collection encoder. It has two modes, wrapped and flattened encoding.
+
+Wrapped arrays have two methods Array() and ArrayWithCustomName() which facilitate array member wrapping.
+By default, a wrapped array members are wrapped with `member` named start element.
+
+	<wrappedArray><member>apple</member><member>tree</member></wrappedArray>
+
+Flattened arrays rely on Value being marked as flattened.
+If a shape is marked as flattened, Array() will use the shape element name as wrapper for array elements.
+
+	<flattenedAarray>apple</flattenedArray><flattenedArray>tree</flattenedArray>
+
+Map
+
+Map is the map encoder. It has two modes, wrapped and flattened encoding.
+
+Wrapped map has Array() method, which facilitate map member wrapping.
+By default, a wrapped map members are wrapped with `entry` named start element.
+
+	<wrappedMap><entry><Key>apple</Key><Value>tree</Value></entry><entry><Key>snow</Key><Value>ice</Value></entry></wrappedMap>
+
+Flattened map rely on Value being marked as flattened.
+If a shape is marked as flattened, Map() will use the shape element name as wrapper for map entry elements.
+
+	<flattenedMap><Key>apple</Key><Value>tree</Value></flattenedMap><flattenedMap><Key>snow</Key><Value>ice</Value></flattenedMap>
+*/
+package xml

--- a/xml/element.go
+++ b/xml/element.go
@@ -1,0 +1,91 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied and modified from Go 1.14 stdlib's encoding/xml
+
+package xml
+
+// A Name represents an XML name (Local) annotated
+// with a name space identifier (Space).
+// In tokens returned by Decoder.Token, the Space identifier
+// is given as a canonical URL, not the short prefix used
+// in the document being parsed.
+type Name struct {
+	Space, Local string
+}
+
+// An Attr represents an attribute in an XML element (Name=Value).
+type Attr struct {
+	Name  Name
+	Value string
+}
+
+/*
+NewAttribute returns a pointer to an attribute.
+It takes in a local name aka attribute name, and value
+representing the attribute value.
+*/
+func NewAttribute(local, value string) Attr {
+	return Attr{
+		Name: Name{
+			Local: local,
+		},
+		Value: value,
+	}
+}
+
+/*
+NewNamespaceAttribute returns a pointer to an attribute.
+It takes in a local name aka attribute name, and value
+representing the attribute value.
+
+NewNamespaceAttribute appends `xmlns:` in front of namespace
+prefix.
+
+For creating a name space attribute representing
+`xmlns:prefix="http://example.com`, the breakdown would be:
+local = "prefix"
+value = "http://example.com"
+*/
+func NewNamespaceAttribute(local, value string) Attr {
+	attr := NewAttribute(local, value)
+
+	// default name space identifier
+	attr.Name.Space = "xmlns"
+	return attr
+}
+
+// A StartElement represents an XML start element.
+type StartElement struct {
+	Name Name
+	Attr []Attr
+}
+
+// Copy creates a new copy of StartElement.
+func (e StartElement) Copy() StartElement {
+	attrs := make([]Attr, len(e.Attr))
+	copy(attrs, e.Attr)
+	e.Attr = attrs
+	return e
+}
+
+// End returns the corresponding XML end element.
+func (e StartElement) End() EndElement {
+	return EndElement{e.Name}
+}
+
+// returns true if start element local name is empty
+func (e StartElement) isZero() bool {
+	return len(e.Name.Local) == 0
+}
+
+// An EndElement represents an XML end element.
+type EndElement struct {
+	Name Name
+}
+
+// returns true if end element local name is empty
+func (e EndElement) isZero() bool {
+	return len(e.Name.Local) == 0
+}

--- a/xml/encoder.go
+++ b/xml/encoder.go
@@ -1,0 +1,51 @@
+package xml
+
+// writer interface used by the xml encoder to write an encoded xml
+// document in a writer.
+type writer interface {
+
+	// Write takes in a byte slice and returns number of bytes written and error
+	Write(p []byte) (n int, err error)
+
+	// WriteRune takes in a rune and returns number of bytes written and error
+	WriteRune(r rune) (n int, err error)
+
+	// WriteString takes in a string and returns number of bytes written and error
+	WriteString(s string) (n int, err error)
+
+	// String method returns a string
+	String() string
+
+	// Bytes return a byte slice.
+	Bytes() []byte
+}
+
+// Encoder is an XML encoder that supports construction of XML values
+// using methods. The encoder takes in a writer and maintains a scratch buffer.
+type Encoder struct {
+	w       writer
+	scratch *[]byte
+}
+
+// NewEncoder returns an XML encoder
+func NewEncoder(w writer) *Encoder {
+	scratch := make([]byte, 64)
+
+	return &Encoder{w: w, scratch: &scratch}
+}
+
+// String returns the string output of the XML encoder
+func (e Encoder) String() string {
+	return e.w.String()
+}
+
+// Bytes returns the []byte slice of the XML encoder
+func (e Encoder) Bytes() []byte {
+	return e.w.Bytes()
+}
+
+// RootElement builds a root element encoding
+// It writes it's start element tag. The value should be closed.
+func (e Encoder) RootElement(element StartElement) Value {
+	return newValue(e.w, e.scratch, element)
+}

--- a/xml/encoder_test.go
+++ b/xml/encoder_test.go
@@ -1,0 +1,512 @@
+package xml_test
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	"github.com/awslabs/smithy-go/xml"
+)
+
+var root = xml.StartElement{Name: xml.Name{Local: "root"}}
+
+func TestEncoder(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		root := encoder.RootElement(root)
+		defer root.Close()
+
+		stringKey := xml.StartElement{Name: xml.Name{Local: "stringKey"}}
+		integerKey := xml.StartElement{Name: xml.Name{Local: "integerKey"}}
+		floatKey := xml.StartElement{Name: xml.Name{Local: "floatKey"}}
+		foo := xml.StartElement{Name: xml.Name{Local: "foo"}}
+		byteSlice := xml.StartElement{Name: xml.Name{Local: "byteSlice"}}
+
+		root.MemberElement(stringKey).String("stringValue")
+		root.MemberElement(integerKey).Integer(1024)
+		root.MemberElement(floatKey).Float(3.14)
+
+		ns := root.MemberElement(foo)
+		defer ns.Close()
+		ns.MemberElement(byteSlice).String("Zm9vIGJhcg==")
+	}()
+
+	e := []byte(`<root><stringKey>stringValue</stringKey><integerKey>1024</integerKey><floatKey>3.14</floatKey><foo><byteSlice>Zm9vIGJhcg==</byteSlice></foo></root>`)
+	verify(t, encoder, e)
+}
+
+func TestEncodeAttribute(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := xml.StartElement{
+			Name: xml.Name{Local: "payload", Space: "baz"},
+			Attr: []xml.Attr{
+				xml.NewAttribute("attrkey", "value"),
+			},
+		}
+
+		obj := encoder.RootElement(r)
+		obj.String("")
+	}()
+
+	expect := `<baz:payload attrkey="value"></baz:payload>`
+
+	verify(t, encoder, []byte(expect))
+}
+
+func TestEncodeNamespace(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		root := encoder.RootElement(root)
+		defer root.Close()
+
+		key := xml.StartElement{
+			Name: xml.Name{Local: "namespace"},
+			Attr: []xml.Attr{
+				xml.NewNamespaceAttribute("prefix", "https://example.com"),
+			},
+		}
+
+		n := root.MemberElement(key)
+		defer n.Close()
+
+		prefix := xml.StartElement{Name: xml.Name{Local: "user"}}
+		n.MemberElement(prefix).String("abc")
+	}()
+
+	e := []byte(`<root><namespace xmlns:prefix="https://example.com"><user>abc</user></namespace></root>`)
+	verify(t, encoder, e)
+}
+
+func TestEncodeEmptyNamespacePrefix(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+	func() {
+		root := encoder.RootElement(root)
+		defer root.Close()
+
+		key := xml.StartElement{
+			Name: xml.Name{Local: "namespace"},
+			Attr: []xml.Attr{
+				xml.NewNamespaceAttribute("", "https://example.com"),
+			},
+		}
+
+		n := root.MemberElement(key)
+		defer n.Close()
+
+		prefix := xml.StartElement{Name: xml.Name{Local: "user"}}
+		n.MemberElement(prefix).String("abc")
+	}()
+
+	e := []byte(`<root><namespace xmlns="https://example.com"><user>abc</user></namespace></root>`)
+	verify(t, encoder, e)
+}
+
+func verify(t *testing.T, encoder *xml.Encoder, e []byte) {
+	if a := encoder.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+
+	if a := encoder.String(); string(encoder.Bytes()) != a {
+		t.Errorf("expected %s, but got %s", e, a)
+	}
+}
+
+func TestEncodeNestedShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// nested `nested` shape
+		nested := xml.StartElement{Name: xml.Name{Local: "nested"}}
+		n1 := r.MemberElement(nested)
+		defer n1.Close()
+
+		// nested `value` shape
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+		n1.MemberElement(value).String("expected value")
+	}()
+
+	e := []byte(`<root><nested><value>expected value</value></nested></root>`)
+	defer verify(t, encoder, e)
+}
+
+func TestEncodeMapString(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// nested `mapStr` shape
+		mapstr := xml.StartElement{Name: xml.Name{Local: "mapstr"}}
+		mapElement := r.MemberElement(mapstr)
+		defer mapElement.Close()
+
+		m := mapElement.Map()
+
+		key := xml.StartElement{Name: xml.Name{Local: "key"}}
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+
+		e := m.Entry()
+		defer e.Close()
+		e.MemberElement(key).String("abc")
+		e.MemberElement(value).Integer(123)
+	}()
+
+	ex := []byte(`<root><mapstr><entry><key>abc</key><value>123</value></entry></mapstr></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeMapFlatten(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+		// nested `mapStr` shape
+		mapstr := xml.StartElement{Name: xml.Name{Local: "mapstr"}}
+		flatElement := r.FlattenedElement(mapstr)
+
+		m := flatElement.Map()
+		e := m.Entry()
+		defer e.Close()
+
+		key := xml.StartElement{Name: xml.Name{Local: "key"}}
+		e.MemberElement(key).String("abc")
+
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+		e.MemberElement(value).Integer(123)
+	}()
+
+	ex := []byte(`<root><mapstr><key>abc</key><value>123</value></mapstr></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeMapNamed(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+		// nested `mapStr` shape
+		mapstr := xml.StartElement{Name: xml.Name{Local: "mapNamed"}}
+		mapElement := r.MemberElement(mapstr)
+		defer mapElement.Close()
+
+		m := mapElement.Map()
+		e := m.Entry()
+		defer e.Close()
+
+		key := xml.StartElement{Name: xml.Name{Local: "namedKey"}}
+		e.MemberElement(key).String("abc")
+
+		value := xml.StartElement{Name: xml.Name{Local: "namedValue"}}
+		e.MemberElement(value).Integer(123)
+	}()
+
+	ex := []byte(`<root><mapNamed><entry><namedKey>abc</namedKey><namedValue>123</namedValue></entry></mapNamed></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeMapShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// nested `mapStr` shape
+		mapstr := xml.StartElement{Name: xml.Name{Local: "mapShape"}}
+		mapElement := r.MemberElement(mapstr)
+		defer mapElement.Close()
+
+		m := mapElement.Map()
+
+		e := m.Entry()
+		defer e.Close()
+
+		key := xml.StartElement{Name: xml.Name{Local: "key"}}
+		e.MemberElement(key).String("abc")
+
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+		n1 := e.MemberElement(value)
+		defer n1.Close()
+
+		shapeVal := xml.StartElement{Name: xml.Name{Local: "shapeVal"}}
+		n1.MemberElement(shapeVal).Integer(1)
+	}()
+
+	ex := []byte(`<root><mapShape><entry><key>abc</key><value><shapeVal>1</shapeVal></value></entry></mapShape></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeMapFlattenShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+		// nested `mapStr` shape
+		mapstr := xml.StartElement{Name: xml.Name{Local: "mapShape"}}
+		flatElement := r.FlattenedElement(mapstr)
+		m := flatElement.Map()
+
+		e := m.Entry()
+		defer e.Close()
+
+		key := xml.StartElement{Name: xml.Name{Local: "key"}}
+		e.MemberElement(key).String("abc")
+
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+		n1 := e.MemberElement(value)
+		defer n1.Close()
+
+		shapeVal := xml.StartElement{Name: xml.Name{Local: "shapeVal"}}
+		n1.MemberElement(shapeVal).Integer(1)
+	}()
+	ex := []byte(`<root><mapShape><key>abc</key><value><shapeVal>1</shapeVal></value></mapShape></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeMapNamedShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// nested `mapStr` shape
+		mapstr := xml.StartElement{Name: xml.Name{Local: "mapNamedShape"}}
+		mapElement := r.MemberElement(mapstr)
+		defer mapElement.Close()
+
+		m := mapElement.Map()
+		e := m.Entry()
+		defer e.Close()
+
+		key := xml.StartElement{Name: xml.Name{Local: "namedKey"}}
+		e.MemberElement(key).String("abc")
+
+		value := xml.StartElement{Name: xml.Name{Local: "namedValue"}}
+		n1 := e.MemberElement(value)
+		defer n1.Close()
+
+		shapeVal := xml.StartElement{Name: xml.Name{Local: "shapeVal"}}
+		n1.MemberElement(shapeVal).Integer(1)
+	}()
+
+	ex := []byte(`<root><mapNamedShape><entry><namedKey>abc</namedKey><namedValue><shapeVal>1</shapeVal></namedValue></entry></mapNamedShape></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeListString(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// Object key `liststr`
+		liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+		m := r.MemberElement(liststr)
+		defer m.Close()
+
+		a := m.Array()
+		a.Member().String("abc")
+		a.Member().Integer(123)
+	}()
+
+	ex := []byte(`<root><liststr><member>abc</member><member>123</member></liststr></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeListFlatten(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// Object key `liststr`
+		liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+		m := r.FlattenedElement(liststr)
+
+		a := m.Array()
+		a.Member().String("abc")
+		a.Member().Integer(123)
+	}()
+
+	ex := []byte(`<root><liststr>abc</liststr><liststr>123</liststr></root>`)
+	verify(t, encoder, ex)
+}
+
+func TestEncodeListNamed(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// Object key `liststr`
+		liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+
+		namedMember := xml.StartElement{Name: xml.Name{Local: "namedMember"}}
+		m := r.MemberElement(liststr)
+		defer m.Close()
+
+		a := m.ArrayWithCustomName(namedMember)
+		a.Member().String("abc")
+		a.Member().Integer(123)
+	}()
+
+	ex := []byte(`<root><liststr><namedMember>abc</namedMember><namedMember>123</namedMember></liststr></root>`)
+	verify(t, encoder, ex)
+}
+
+//
+func TestEncodeListShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// Object key `liststr`
+		liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+
+		m := r.MemberElement(liststr)
+		defer m.Close()
+
+		a := m.Array()
+
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+
+		m1 := a.Member()
+		m1.MemberElement(value).String("abc")
+		m1.Close()
+
+		m2 := a.Member()
+		m2.MemberElement(value).Integer(123)
+		m2.Close()
+	}()
+
+	ex := []byte(`<root><liststr><member><value>abc</value></member><member><value>123</value></member></liststr></root>`)
+	verify(t, encoder, ex)
+}
+
+//
+func TestEncodeListFlattenShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// Object key `liststr`
+		liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+
+		m := r.FlattenedElement(liststr)
+
+		a := m.Array()
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+
+		m1 := a.Member()
+		m1.MemberElement(value).String("abc")
+		m1.Close()
+
+		m2 := a.Member()
+		m2.MemberElement(value).Integer(123)
+		m2.Close()
+	}()
+
+	ex := []byte(`<root><liststr><value>abc</value></liststr><liststr><value>123</value></liststr></root>`)
+	verify(t, encoder, ex)
+}
+
+//
+func TestEncodeListNamedShape(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	func() {
+		r := encoder.RootElement(root)
+		defer r.Close()
+
+		// Object key `liststr`
+		liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+		namedMember := xml.StartElement{Name: xml.Name{Local: "namedMember"}}
+
+		// member element
+		m := r.MemberElement(liststr)
+		defer m.Close()
+
+		// Build array
+		a := m.ArrayWithCustomName(namedMember)
+
+		value := xml.StartElement{Name: xml.Name{Local: "value"}}
+		m1 := a.Member()
+		m1.MemberElement(value).String("abc")
+		m1.Close()
+
+		m2 := a.Member()
+		m2.MemberElement(value).Integer(123)
+		m2.Close()
+	}()
+
+	ex := []byte(`<root><liststr><namedMember><value>abc</value></namedMember><namedMember><value>123</value></namedMember></liststr></root>`)
+	verify(t, encoder, ex)
+}
+
+// ExampleEncoder is the example function on how to use an encoder
+func ExampleEncoder() {
+	b := bytes.NewBuffer(nil)
+	encoder := xml.NewEncoder(b)
+
+	// expected encoded xml document is :
+	// `<root><liststr><namedMember><value>abc</value></namedMember><namedMember><value>123</value></namedMember></liststr></root>`
+	defer log.Printf("Encoded xml document: %v", encoder.String())
+
+	r := encoder.RootElement(root)
+	defer r.Close()
+
+	// Object key `liststr`
+	liststr := xml.StartElement{Name: xml.Name{Local: "liststr"}}
+	namedMember := xml.StartElement{Name: xml.Name{Local: "namedMember"}}
+
+	// member element
+	m := r.MemberElement(liststr)
+	defer m.Close()
+
+	// Build array
+	a := m.ArrayWithCustomName(namedMember)
+
+	value := xml.StartElement{Name: xml.Name{Local: "value"}}
+	m1 := a.Member()
+	m1.MemberElement(value).String("abc")
+	m1.Close()
+
+	m2 := a.Member()
+	m2.MemberElement(value).Integer(123)
+	m2.Close()
+}

--- a/xml/escape.go
+++ b/xml/escape.go
@@ -1,0 +1,121 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied and modified from Go 1.14 stdlib's encoding/xml
+
+package xml
+
+import (
+	"unicode/utf8"
+)
+
+// Copied from Go 1.14 stdlib's encoding/xml
+var (
+	escQuot = []byte("&#34;") // shorter than "&quot;"
+	escApos = []byte("&#39;") // shorter than "&apos;"
+	escAmp  = []byte("&amp;")
+	escLT   = []byte("&lt;")
+	escGT   = []byte("&gt;")
+	escTab  = []byte("&#x9;")
+	escNL   = []byte("&#xA;")
+	escCR   = []byte("&#xD;")
+	escFFFD = []byte("\uFFFD") // Unicode replacement character
+)
+
+// Decide whether the given rune is in the XML Character Range, per
+// the Char production of https://www.xml.com/axml/testaxml.htm,
+// Section 2.2 Characters.
+func isInCharacterRange(r rune) (inrange bool) {
+	return r == 0x09 ||
+		r == 0x0A ||
+		r == 0x0D ||
+		r >= 0x20 && r <= 0xD7FF ||
+		r >= 0xE000 && r <= 0xFFFD ||
+		r >= 0x10000 && r <= 0x10FFFF
+}
+
+// TODO: When do we need to escape the string?
+// Based on encoding/xml escapeString from the Go Standard Library.
+// https://golang.org/src/encoding/xml/xml.go
+func escapeString(e writer, s string) {
+	var esc []byte
+	last := 0
+	for i := 0; i < len(s); {
+		r, width := utf8.DecodeRuneInString(s[i:])
+		i += width
+		switch r {
+		case '"':
+			esc = escQuot
+		case '\'':
+			esc = escApos
+		case '&':
+			esc = escAmp
+		case '<':
+			esc = escLT
+		case '>':
+			esc = escGT
+		case '\t':
+			esc = escTab
+		case '\n':
+			esc = escNL
+		case '\r':
+			esc = escCR
+		default:
+			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
+				esc = escFFFD
+				break
+			}
+			continue
+		}
+		e.WriteString(s[last : i-width])
+		e.Write(esc)
+		last = i
+	}
+	e.WriteString(s[last:])
+}
+
+// escapeText writes to w the properly escaped XML equivalent
+// of the plain text data s. If escapeNewline is true, newline
+// characters will be escaped.
+//
+// Based on encoding/xml escapeText from the Go Standard Library.
+// https://golang.org/src/encoding/xml/xml.go
+func escapeText(e writer, s []byte) {
+	var esc []byte
+	last := 0
+	for i := 0; i < len(s); {
+		r, width := utf8.DecodeRune(s[i:])
+		i += width
+		switch r {
+		case '"':
+			esc = escQuot
+		case '\'':
+			esc = escApos
+		case '&':
+			esc = escAmp
+		case '<':
+			esc = escLT
+		case '>':
+			esc = escGT
+		case '\t':
+			esc = escTab
+		case '\n':
+			// TODO: This always escapes newline, which is different than stdlib's optional
+			// escape of new line
+			esc = escNL
+		case '\r':
+			esc = escCR
+		default:
+			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
+				esc = escFFFD
+				break
+			}
+			continue
+		}
+		e.Write(s[last : i-width])
+		e.Write(esc)
+		last = i
+	}
+	e.Write(s[last:])
+}

--- a/xml/map.go
+++ b/xml/map.go
@@ -1,0 +1,53 @@
+package xml
+
+// mapEntryWrapper is the default member wrapper start element for XML Map entry
+var mapEntryWrapper = StartElement{
+	Name: Name{Local: "entry"},
+}
+
+// Map represents the encoding of a XML map type
+type Map struct {
+	w       writer
+	scratch *[]byte
+
+	// member start element is the map entry wrapper start element
+	memberStartElement StartElement
+
+	// isFlattened returns true if the map is a flattened map
+	isFlattened bool
+}
+
+// newMap returns a map encoder which sets the default map
+// entry wrapper to `entry`.
+//
+// A map `someMap : {{key:"abc", value:"123"}}` is represented as
+// `<someMap><entry><key>abc<key><value>123</value></entry></someMap>`.
+func newMap(w writer, scratch *[]byte) *Map {
+	return &Map{
+		w:                  w,
+		scratch:            scratch,
+		memberStartElement: mapEntryWrapper,
+	}
+}
+
+// newFlattenedMap returns a map encoder which sets the map
+// entry wrapper to the passed in memberWrapper`.
+//
+// A flattened map `someMap : {{key:"abc", value:"123"}}` is represented as
+// `<someMap><key>abc<key><value>123</value></someMap>`.
+func newFlattenedMap(w writer, scratch *[]byte, memberWrapper StartElement) *Map {
+	return &Map{
+		w:                  w,
+		scratch:            scratch,
+		memberStartElement: memberWrapper,
+		isFlattened:        true,
+	}
+}
+
+// Entry returns a Value encoder with map's element.
+// It writes the member wrapper start tag for each entry.
+func (m *Map) Entry() Value {
+	v := newValue(m.w, m.scratch, m.memberStartElement)
+	v.isFlattened = m.isFlattened
+	return v
+}

--- a/xml/map_test.go
+++ b/xml/map_test.go
@@ -1,0 +1,77 @@
+package xml
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWrappedMap(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	func() {
+		m := newMap(buffer, &scratch)
+
+		key := StartElement{Name: Name{Local: "key"}}
+		value := StartElement{Name: Name{Local: "value"}}
+
+		// map entry
+		e := m.Entry()
+		e.MemberElement(key).String("example-key1")
+		e.MemberElement(value).String("example1")
+		e.Close()
+
+		// map entry
+		e = m.Entry()
+		e.MemberElement(key).String("example-key2")
+		e.MemberElement(value).String("example2")
+		e.Close()
+
+		// map entry
+		e = m.Entry()
+		e.MemberElement(key).String("example-key3")
+		e.MemberElement(value).String("example3")
+		e.Close()
+	}()
+
+	ex := []byte(`<entry><key>example-key1</key><value>example1</value></entry><entry><key>example-key2</key><value>example2</value></entry><entry><key>example-key3</key><value>example3</value></entry>`)
+	if a := buffer.Bytes(); bytes.Compare(ex, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", ex, a)
+	}
+}
+
+func TestFlattenedMapWithCustomName(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	func() {
+		root := StartElement{Name: Name{Local: "flatMap"}}
+		m := newFlattenedMap(buffer, &scratch, root)
+
+		key := StartElement{Name: Name{Local: "key"}}
+		value := StartElement{Name: Name{Local: "value"}}
+
+		// map entry
+		e := m.Entry()
+		e.MemberElement(key).String("example-key1")
+		e.MemberElement(value).String("example1")
+		e.Close()
+
+		// map entry
+		e = m.Entry()
+		e.MemberElement(key).String("example-key2")
+		e.MemberElement(value).String("example2")
+		e.Close()
+
+		// map entry
+		e = m.Entry()
+		e.MemberElement(key).String("example-key3")
+		e.MemberElement(value).String("example3")
+		e.Close()
+	}()
+
+	ex := []byte(`<flatMap><key>example-key1</key><value>example1</value></flatMap><flatMap><key>example-key2</key><value>example2</value></flatMap><flatMap><key>example-key3</key><value>example3</value></flatMap>`)
+	if a := buffer.Bytes(); bytes.Compare(ex, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", ex, a)
+	}
+}

--- a/xml/value.go
+++ b/xml/value.go
@@ -1,0 +1,302 @@
+package xml
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"strconv"
+
+	"github.com/awslabs/smithy-go/internal/encoding"
+)
+
+// Value represents an XML Value type
+// XML Value types: Object, Array, Map, String, Number, Boolean.
+type Value struct {
+	w       writer
+	scratch *[]byte
+
+	// xml start element is the associated start element for the Value
+	startElement StartElement
+
+	// indicates if the Value represents a flattened shape
+	isFlattened bool
+}
+
+// newFlattenedValue returns a Value encoder. newFlattenedValue does NOT write the start element tag
+func newFlattenedValue(w writer, scratch *[]byte, startElement StartElement) Value {
+	return Value{
+		w:            w,
+		scratch:      scratch,
+		startElement: startElement,
+	}
+}
+
+// newValue writes the start element xml tag and returns a Value
+func newValue(w writer, scratch *[]byte, startElement StartElement) Value {
+	writeStartElement(w, startElement)
+	return Value{w: w, scratch: scratch, startElement: startElement}
+}
+
+// writeStartElement takes in a start element and writes it.
+// It handles namespace, attributes in start element.
+func writeStartElement(w writer, el StartElement) error {
+	if el.isZero() {
+		return fmt.Errorf("xml start element cannot be nil")
+	}
+
+	w.WriteRune(leftAngleBracket)
+
+	if len(el.Name.Space) != 0 {
+		escapeString(w, el.Name.Space)
+		w.WriteRune(colon)
+	}
+	escapeString(w, el.Name.Local)
+	for _, attr := range el.Attr {
+		w.WriteRune(' ')
+		writeAttribute(w, &attr)
+	}
+
+	w.WriteRune(rightAngleBracket)
+	return nil
+}
+
+// writeAttribute writes an attribute from a provided Attribute
+// For a namespace attribute, the attr.Name.Space must be defined as "xmlns".
+// https://www.w3.org/TR/REC-xml-names/#NT-DefaultAttName
+func writeAttribute(w writer, attr *Attr) {
+	// if local, space both are not empty
+	if len(attr.Name.Space) != 0 && len(attr.Name.Local) != 0 {
+		escapeString(w, attr.Name.Space)
+		w.WriteRune(colon)
+	}
+
+	// if prefix is empty, the default `xmlns` space should be used as prefix.
+	if len(attr.Name.Local) == 0 {
+		attr.Name.Local = attr.Name.Space
+	}
+
+	escapeString(w, attr.Name.Local)
+	w.WriteRune(equals)
+	w.WriteRune(quote)
+	escapeString(w, attr.Value)
+	w.WriteRune(quote)
+}
+
+// writeEndElement takes in a end element and writes it.
+func writeEndElement(w writer, el EndElement) error {
+	if el.isZero() {
+		return fmt.Errorf("xml end element cannot be nil")
+	}
+
+	w.WriteRune(leftAngleBracket)
+	w.WriteRune(forwardSlash)
+
+	if len(el.Name.Space) != 0 {
+		escapeString(w, el.Name.Space)
+		w.WriteRune(colon)
+	}
+	escapeString(w, el.Name.Local)
+	w.WriteRune(rightAngleBracket)
+
+	return nil
+}
+
+// String encodes v as a XML string.
+// It will auto close the parent xml element tag.
+func (xv Value) String(v string) {
+	escapeString(xv.w, v)
+	xv.Close()
+}
+
+// Byte encodes v as a XML number.
+// It will auto close the parent xml element tag.
+func (xv Value) Byte(v int8) {
+	xv.Long(int64(v))
+}
+
+// Short encodes v as a XML number.
+// It will auto close the parent xml element tag.
+func (xv Value) Short(v int16) {
+	xv.Long(int64(v))
+}
+
+// Integer encodes v as a XML number.
+// It will auto close the parent xml element tag.
+func (xv Value) Integer(v int32) {
+	xv.Long(int64(v))
+}
+
+// Long encodes v as a XML number.
+// It will auto close the parent xml element tag.
+func (xv Value) Long(v int64) {
+	*xv.scratch = strconv.AppendInt((*xv.scratch)[:0], v, 10)
+	xv.w.Write(*xv.scratch)
+
+	xv.Close()
+}
+
+// Float encodes v as a XML number.
+// It will auto close the parent xml element tag.
+func (xv Value) Float(v float32) {
+	xv.float(float64(v), 32)
+	xv.Close()
+}
+
+// Double encodes v as a XML number.
+// It will auto close the parent xml element tag.
+func (xv Value) Double(v float64) {
+	xv.float(v, 64)
+	xv.Close()
+}
+
+func (xv Value) float(v float64, bits int) {
+	*xv.scratch = encoding.EncodeFloat((*xv.scratch)[:0], v, bits)
+	xv.w.Write(*xv.scratch)
+}
+
+// Boolean encodes v as a XML boolean.
+// It will auto close the parent xml element tag.
+func (xv Value) Boolean(v bool) {
+	*xv.scratch = strconv.AppendBool((*xv.scratch)[:0], v)
+	xv.w.Write(*xv.scratch)
+
+	xv.Close()
+}
+
+// Base64EncodeBytes writes v as a base64 value in XML string.
+// It will auto close the parent xml element tag.
+func (xv Value) Base64EncodeBytes(v []byte) {
+	encodeByteSlice(xv.w, (*xv.scratch)[:0], v)
+	xv.Close()
+}
+
+// BigInteger encodes v big.Int as XML value.
+// It will auto close the parent xml element tag.
+func (xv Value) BigInteger(v *big.Int) {
+	xv.w.Write([]byte(v.Text(10)))
+	xv.Close()
+}
+
+// BigDecimal encodes v big.Float as XML value.
+// It will auto close the parent xml element tag.
+func (xv Value) BigDecimal(v *big.Float) {
+	if i, accuracy := v.Int64(); accuracy == big.Exact {
+		xv.Long(i)
+		return
+	}
+
+	xv.w.Write([]byte(v.Text('e', -1)))
+	xv.Close()
+}
+
+// Write writes v directly to the xml document
+// if escapeXMLText is set to true, write will escape text.
+// It will auto close the parent xml element tag.
+func (xv Value) Write(v []byte, escapeXMLText bool) {
+	// escape and write xml text
+	if escapeXMLText {
+		escapeText(xv.w, v)
+	} else {
+		// write xml directly
+		xv.w.Write(v)
+	}
+
+	xv.Close()
+}
+
+// MemberElement does member element encoding. It returns a Value.
+// Member Element method should be used for all shapes except flattened shapes.
+//
+// A call to MemberElement will write nested element tags directly using the
+// provided start element. The value returned by MemberElement should be closed.
+func (xv Value) MemberElement(element StartElement) Value {
+	return newValue(xv.w, xv.scratch, element)
+}
+
+// FlattenedElement returns flattened element encoding. It returns a Value.
+// This method should be used for flattened shapes.
+//
+// Unlike MemberElement, flattened element will NOT write element tags
+// directly for the associated start element.
+//
+// The value returned by the FlattenedElement does not need to be closed.
+func (xv Value) FlattenedElement(element StartElement) Value {
+	v := newFlattenedValue(xv.w, xv.scratch, element)
+	v.isFlattened = true
+	return v
+}
+
+// Array returns an array encoder. By default, the members of array are
+// wrapped with `<member>` element tag.
+// If value is marked as flattened, the start element is used to wrap the members instead of
+// the `<member>` element.
+func (xv Value) Array() *Array {
+	return newArray(xv.w, xv.scratch, arrayMemberWrapper, xv.startElement, xv.isFlattened)
+}
+
+/*
+ArrayWithCustomName returns an array encoder.
+
+It takes named start element as an argument, the named start element will used to wrap xml array entries.
+for eg, `<someList><customName>entry1</customName></someList>`
+Here `customName` named start element will be wrapped on each array member.
+*/
+func (xv Value) ArrayWithCustomName(element StartElement) *Array {
+	return newArray(xv.w, xv.scratch, element, xv.startElement, xv.isFlattened)
+}
+
+/*
+Map returns a map encoder. By default, the map entries are
+wrapped with `<entry>` element tag.
+
+If value is marked as flattened, the start element is used to wrap the entry instead of
+the `<member>` element.
+*/
+func (xv Value) Map() *Map {
+	// flattened map
+	if xv.isFlattened {
+		return newFlattenedMap(xv.w, xv.scratch, xv.startElement)
+	}
+
+	// un-flattened map
+	return newMap(xv.w, xv.scratch)
+}
+
+// encodeByteSlice is modified copy of json encoder's encodeByteSlice.
+// It is used to base64 encode a byte slice.
+func encodeByteSlice(w writer, scratch []byte, v []byte) {
+	if v == nil {
+		return
+	}
+
+	encodedLen := base64.StdEncoding.EncodedLen(len(v))
+	if encodedLen <= len(scratch) {
+		// If the encoded bytes fit in e.scratch, avoid an extra
+		// allocation and use the cheaper Encoding.Encode.
+		dst := scratch[:encodedLen]
+		base64.StdEncoding.Encode(dst, v)
+		w.Write(dst)
+	} else if encodedLen <= 1024 {
+		// The encoded bytes are short enough to allocate for, and
+		// Encoding.Encode is still cheaper.
+		dst := make([]byte, encodedLen)
+		base64.StdEncoding.Encode(dst, v)
+		w.Write(dst)
+	} else {
+		// The encoded bytes are too long to cheaply allocate, and
+		// Encoding.Encode is no longer noticeably cheaper.
+		enc := base64.NewEncoder(base64.StdEncoding, w)
+		enc.Write(v)
+		enc.Close()
+	}
+}
+
+// IsFlattened returns true if value is for flattened shape.
+func (xv Value) IsFlattened() bool {
+	return xv.isFlattened
+}
+
+// Close closes the value.
+func (xv Value) Close() {
+	writeEndElement(xv.w, xv.startElement.End())
+}

--- a/xml/value_test.go
+++ b/xml/value_test.go
@@ -1,0 +1,212 @@
+package xml
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"testing"
+)
+
+var (
+	oneInt   = new(big.Int).SetInt64(1)
+	oneFloat = new(big.Float).SetFloat64(1.0)
+)
+
+func TestValue(t *testing.T) {
+	nested := StartElement{Name: Name{Local: "nested"}}
+
+	cases := map[string]struct {
+		setter   func(Value)
+		expected string
+	}{
+		"string value": {
+			setter: func(value Value) {
+				value.String("foo")
+			},
+			expected: `foo`,
+		},
+		"string escaped": {
+			setter: func(value Value) {
+				value.String("{\"foo\":\"bar\"}")
+			},
+			expected: fmt.Sprintf("{%sfoo%s:%sbar%s}", escQuot, escQuot, escQuot, escQuot),
+		},
+		"integer": {
+			setter: func(value Value) {
+				value.Long(1024)
+			},
+			expected: `1024`,
+		},
+		"float": {
+			setter: func(value Value) {
+				value.Double(1e20)
+			},
+			expected: `100000000000000000000`,
+		},
+		"float exponent component": {
+			setter: func(value Value) {
+				value.Double(3e22)
+			},
+			expected: `3e+22`,
+		},
+		"boolean true": {
+			setter: func(value Value) {
+				value.Boolean(true)
+			},
+			expected: `true`,
+		},
+		"boolean false": {
+			setter: func(value Value) {
+				value.Boolean(false)
+			},
+			expected: `false`,
+		},
+		"encode bytes": {
+			setter: func(value Value) {
+				value.Base64EncodeBytes([]byte("foo bar"))
+			},
+			expected: `Zm9vIGJhcg==`,
+		},
+		"encode bytes nil": {
+			setter: func(value Value) {
+				value.Base64EncodeBytes(nil)
+			},
+			expected: ``,
+		},
+		"object": {
+			setter: func(value Value) {
+				defer value.Close()
+				value.MemberElement(nested).String("value")
+			},
+			expected: `<nested>value</nested>`,
+		},
+		"null": {
+			setter: func(value Value) {
+				value.Close()
+			},
+			expected: ``,
+		},
+		"nullWithRoot": {
+			setter: func(value Value) {
+				defer value.Close()
+				o := value.MemberElement(nested)
+				defer o.Close()
+			},
+			expected: `<nested></nested>`,
+		},
+		"write text": {
+			setter: func(value Value) {
+				defer value.Close()
+				o := value.MemberElement(nested)
+				o.Write([]byte(`{"nested":"value"}`), false)
+			},
+			expected: `<nested>{"nested":"value"}</nested>`,
+		},
+		"write escaped text": {
+			setter: func(value Value) {
+				defer value.Close()
+				o := value.MemberElement(nested)
+				o.Write([]byte(`{"nested":"value"}`), true)
+			},
+			expected: fmt.Sprintf("<nested>{%snested%s:%svalue%s}</nested>", escQuot, escQuot, escQuot, escQuot),
+		},
+		"bigInteger": {
+			setter: func(value Value) {
+				v := new(big.Int).SetInt64(math.MaxInt64)
+				value.BigInteger(v.Sub(v, oneInt))
+			},
+			expected: strconv.FormatInt(math.MaxInt64-1, 10),
+		},
+		"bigInteger > int64": {
+			setter: func(value Value) {
+				v := new(big.Int).SetInt64(math.MaxInt64)
+				value.BigInteger(v.Add(v, oneInt))
+			},
+			expected: "9223372036854775808",
+		},
+		"bigInteger < int64": {
+			setter: func(value Value) {
+				v := new(big.Int).SetInt64(math.MinInt64)
+				value.BigInteger(v.Sub(v, oneInt))
+			},
+			expected: "-9223372036854775809",
+		},
+		"bigFloat": {
+			setter: func(value Value) {
+				v := new(big.Float).SetFloat64(math.MaxFloat64)
+				value.BigDecimal(v.Sub(v, oneFloat))
+			},
+			expected: strconv.FormatFloat(math.MaxFloat64-1, 'e', -1, 64),
+		},
+		"bigFloat fits in int64": {
+			setter: func(value Value) {
+				v := new(big.Float).SetInt64(math.MaxInt64)
+				value.BigDecimal(v)
+			},
+			expected: "9223372036854775807",
+		},
+	}
+	scratch := make([]byte, 64)
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := bytes.NewBuffer(nil)
+			root := StartElement{Name: Name{Local: "root"}}
+			value := newValue(b, &scratch, root)
+			tt.setter(value)
+
+			if e, a := []byte("<root>"+tt.expected+"</root>"), b.Bytes(); bytes.Compare(e, a) != 0 {
+				t.Errorf("expected %+q, but got %+q", e, a)
+			}
+		})
+	}
+}
+
+func TestWrappedValue(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	func() {
+		root := StartElement{Name: Name{Local: "root"}}
+		object := newValue(buffer, &scratch, root)
+		defer object.Close()
+
+		foo := StartElement{Name: Name{Local: "foo"}}
+		faz := StartElement{Name: Name{Local: "faz"}}
+
+		object.MemberElement(foo).String("bar")
+		object.MemberElement(faz).String("baz")
+	}()
+
+	e := []byte(`<root><foo>bar</foo><faz>baz</faz></root>`)
+	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+}
+
+func TestWrappedValueWithNameSpaceAndAttributes(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	func() {
+		root := StartElement{Name: Name{Local: "root"}}
+		object := newValue(buffer, &scratch, root)
+		defer object.Close()
+
+		foo := StartElement{Name: Name{Local: "foo"}, Attr: []Attr{
+			NewNamespaceAttribute("newspace", "https://endpoint.com"),
+			NewAttribute("attrName", "attrValue"),
+		}}
+		faz := StartElement{Name: Name{Local: "faz"}}
+
+		object.MemberElement(foo).String("bar")
+		object.MemberElement(faz).String("baz")
+	}()
+
+	e := []byte(`<root><foo xmlns:newspace="https://endpoint.com" attrName="attrValue">bar</foo><faz>baz</faz></root>`)
+	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+}


### PR DESCRIPTION
* Adds the XML encoder to help serialize xml documents.
* Adds an assert-xml library to compare two xml documents. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
