### PR TITLE
Add support for header list of timestamp HTTP Date format

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -319,34 +319,11 @@ public final class CodegenUtils {
      * @param shape the list or set shape.
      * @return The unpacked CollectionShape.
      */
-    public static CollectionShape asCollectionShape(Shape shape) {
-        switch (shape.getType()) {
-            case LIST:
-                return shape.asListShape().get();
-            case SET:
-                return shape.asSetShape().get();
-            default:
-                throw new CodegenException(
-                        "expect list or set shape type, got " + shape.getType() + ", " + shape.getId());
+    public static CollectionShape expectCollectionShape(Shape shape) {
+        if (shape instanceof CollectionShape) {
+            return (CollectionShape) (shape);
         }
-    }
 
-    /**
-     * Returns the collection's member shape if the shape type is a collection. Throws and exception if the passed in
-     * shape is not a list or set.
-     *
-     * @param shape the list or set shape to get the member from.
-     * @return member shape of the list or set.
-     */
-    public static MemberShape getShapeCollectionMember(Shape shape) {
-        switch (shape.getType()) {
-            case LIST:
-                return shape.asListShape().get().getMember();
-            case SET:
-                return shape.asSetShape().get().getMember();
-            default:
-                throw new CodegenException(
-                        "expect list or set shape type, got " + shape.getType() + ", " + shape.getId());
-        }
+        throw new CodegenException("expect shape " + shape.getId() + " to be Collection, was " + shape.getType());
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -309,5 +310,43 @@ public final class CodegenUtils {
         }
 
         return !shape.hasTrait(EnumTrait.class);
+    }
+
+    /**
+     * Returns the shape unpacked as a CollectionShape. Throws and exception if the passed in
+     * shape is not a list or set.
+     *
+     * @param shape the list or set shape.
+     * @return The unpacked CollectionShape.
+     */
+    public static CollectionShape asCollectionShape(Shape shape) {
+        switch (shape.getType()) {
+            case LIST:
+                return shape.asListShape().get();
+            case SET:
+                return shape.asSetShape().get();
+            default:
+                throw new CodegenException(
+                        "expect list or set shape type, got " + shape.getType() + ", " + shape.getId());
+        }
+    }
+
+    /**
+     * Returns the collection's member shape if the shape type is a collection. Throws and exception if the passed in
+     * shape is not a list or set.
+     *
+     * @param shape the list or set shape to get the member from.
+     * @return member shape of the list or set.
+     */
+    public static MemberShape getShapeCollectionMember(Shape shape) {
+        switch (shape.getType()) {
+            case LIST:
+                return shape.asListShape().get().getMember();
+            case SET:
+                return shape.asSetShape().get().getMember();
+            default:
+                throw new CodegenException(
+                        "expect list or set shape type, got " + shape.getType() + ", " + shape.getId());
+        }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -360,9 +360,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the document serializer logic for the serializer middleware body.
      *
-     * @param context the generation context
-     * @param operation      the operation
-     * @param generator      middleware generator definition
+     * @param context   the generation context
+     * @param operation the operation
+     * @param generator middleware generator definition
      */
     protected abstract void writeMiddlewareDocumentSerializerDelegator(
             GenerationContext context,
@@ -373,10 +373,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the payload serializer logic for the serializer middleware body.
      *
-     * @param context the generation context
-     * @param operation      the operation
-     * @param memberShape    the payload target member
-     * @param generator      middleware generator definition
+     * @param context     the generation context
+     * @param operation   the operation
+     * @param memberShape the payload target member
+     * @param generator   middleware generator definition
      */
     protected abstract void writeMiddlewarePayloadSerializerDelegator(
             GenerationContext context,
@@ -388,9 +388,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the document deserializer logic for the deserializer middleware body.
      *
-     * @param context the generation context
-     * @param operation      the operation
-     * @param generator      middleware generator definition
+     * @param context   the generation context
+     * @param operation the operation
+     * @param generator middleware generator definition
      */
     protected abstract void writeMiddlewareDocumentDeserializerDelegator(
             GenerationContext context,
@@ -526,6 +526,18 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             default:
                 throw new CodegenException("Unknown timestamp format");
         }
+    }
+
+    private boolean isHttpDateTimestampHeader(Model model, HttpBinding.Location location, MemberShape memberShape) {
+        Shape targetShape = model.expectShape(memberShape.getTarget().toShapeId());
+        if (targetShape.getType() != ShapeType.TIMESTAMP) {
+            return false;
+        }
+
+        TimestampFormatTrait.Format format = model.getKnowledge(HttpBindingIndex.class).determineTimestampFormat(
+                memberShape, location, getDocumentTimestampFormat());
+
+        return format == Format.HTTP_DATE;
     }
 
     private void writeHttpBindingSetter(
@@ -915,13 +927,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 writer.write("if err != nil { return err }");
                 return "b";
             case SET:
-                // handle set as target shape
-                Shape targetValueSetShape = model.expectShape(targetShape.asSetShape().get().getMember().getTarget());
-                return getHttpHeaderCollectionDeserializer(writer, model, symbolProvider, targetValueSetShape, binding,
-                        operand);
             case LIST:
-                // handle list as target shape
-                Shape targetValueListShape = model.expectShape(targetShape.asListShape().get().getMember().getTarget());
+                // handle list/Set as target shape
+                Shape targetValueListShape = model.expectShape(
+                        CodegenUtils.getShapeCollectionMember(targetShape).getTarget());
                 return getHttpHeaderCollectionDeserializer(writer, model, symbolProvider, targetValueListShape, binding,
                         operand);
             default:
@@ -942,17 +951,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         String operandValue = operand + "Val";
         writer.openBlock("for _, $L := range $L {", "}", operandValue, operand, () -> {
-            // TODO does not support Timestamp datetime formatted header lists
-            writer.addUseImports(SmithyGoDependency.STRINGS);
-            String operandValueSplit = operandValue + "Part";
-            writer.openBlock("for _, $L := range strings.Split($L, \",\") {", "}", operandValueSplit, operandValue,
-                    () -> {
-                        String value = generateHttpHeaderValue(writer, model, symbolProvider, targetShape, binding,
-                                operandValueSplit);
-                        writer.write("list = append(list, $L)",
-                                CodegenUtils.generatePointerValueIfPointable(writer, targetShape, value));
-                    });
-
+            String value = generateHttpHeaderValue(writer, model, symbolProvider, targetShape, binding,
+                    operandValue);
+            writer.write("list = append(list, $L)",
+                    CodegenUtils.generatePointerValueIfPointable(writer, targetShape, value));
         });
         return "list";
     }
@@ -992,11 +994,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         writer.openBlock("if headerValues := response.Header.Values($S); len(headerValues) != 0 {", "}",
                 binding.getLocationName(), () -> {
+
                     String operand = "headerValues";
-                    if (targetShape.getType() != ShapeType.LIST && targetShape.getType() != ShapeType.SET) {
-                        // TODO should this be the first or last header value received?
-                        operand += "[0]";
-                    }
+                    operand = writeHeaderValueAccessor(writer, model, targetShape, binding, operand);
+
                     String value = generateHttpHeaderValue(writer, model, symbolProvider, targetShape, binding,
                             operand);
                     writer.write("v.$L = $L", memberName,
@@ -1032,15 +1033,69 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         });
 
                         String operand = "headerValues";
-                        if (valueMemberTarget.getType() != ShapeType.LIST
-                                && valueMemberTarget.getType() != ShapeType.SET) {
-                            operand += "[0]";
-                        }
+                        operand = writeHeaderValueAccessor(writer, model, targetShape, binding, operand);
+
                         String value = generateHttpHeaderValue(writer, model, symbolProvider, valueMemberTarget,
                                 binding, operand);
                         writer.write("v.$L[headerKey[lenPrefix:]] = $L", memberName,
                                 CodegenUtils.generatePointerValueIfPointable(writer, valueMemberTarget, value));
                     });
+        });
+    }
+
+    /**
+     * Returns the header value accessor operand, and also if the target shape is a list/set will write the splitting
+     * of the header values by comma(,) utility helper.
+     *
+     * @param writer      writer
+     * @param model       smithy model
+     * @param targetShape target shape
+     * @param binding     http binding location
+     * @param operand     operand of the header values.
+     * @return returns operand for accessing the header values
+     */
+    private String writeHeaderValueAccessor(
+            GoWriter writer, Model model, Shape targetShape, HttpBinding binding, String operand
+    ) {
+        switch (targetShape.getType()) {
+            case LIST:
+            case SET:
+                writerHeaderListValuesSplit(writer, model, CodegenUtils.asCollectionShape(targetShape), binding,
+                        operand);
+                break;
+            default:
+                // TODO should this be the first or last header value received?
+                operand += "[0]";
+                break;
+        }
+
+        return operand;
+    }
+
+    /**
+     * Writes the utility to split split comma separate header values into a single list for consistent iteration. Also
+     * has special case handling for HttpDate timestamp format when serialized as a header list. Assigns the split
+     * header values back to the same operand name.
+     *
+     * @param writer  writer
+     * @param model   smithy model
+     * @param shape   target collection shape
+     * @param binding http binding location
+     * @param operand operand of the header values.
+     */
+    private void writerHeaderListValuesSplit(
+            GoWriter writer, Model model, CollectionShape shape, HttpBinding binding, String operand
+    ) {
+        writer.openBlock("{", "}", () -> {
+            writer.write("var err error");
+            if (isHttpDateTimestampHeader(model, binding.getLocation(), shape.getMember())) {
+                writer.write("$L, err = smithyhttp.SplitHTTPDateTimestampHeaderListValues($L)", operand, operand);
+            } else {
+                writer.write("$L, err = smithyhttp.SplitHeaderListValues($L)", operand, operand);
+            }
+            writer.openBlock("if err != nil {", "}", () -> {
+                writer.write("return err");
+            });
         });
     }
 
@@ -1119,7 +1174,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * </ul>
      *
      * @param context The generation context.
-     * @param shape The error shape.
+     * @param shape   The error shape.
      */
     protected abstract void deserializeError(GenerationContext context, StructureShape shape);
 }

--- a/transport/http/headerlist.go
+++ b/transport/http/headerlist.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"fmt"
+	"strings"
+)
+
+func splitHeaderListValues(vs []string, splitFn func(string) ([]string, error)) ([]string, error) {
+	for i := 0; i < len(vs); i++ {
+		if len(vs[i]) == 0 {
+			continue
+		}
+
+		parts, err := splitFn(vs[i])
+		if err != nil {
+			return nil, err
+		}
+		if len(parts) < 2 {
+			continue
+		}
+
+		tmp := make([]string, len(vs)+len(parts)-1)
+		copy(tmp, vs[:i])
+
+		for j, p := range parts {
+			tmp[i+j] = strings.TrimSpace(p)
+		}
+
+		copy(tmp[i+len(parts):], vs[i+1:])
+
+		vs = tmp
+		i += len(parts) - 1
+	}
+
+	return vs, nil
+}
+
+// SplitHeaderListValues attempts to split the elements of the slice by commas,
+// and return a list of all values separated. Returns error if unable to
+// separate the values.
+func SplitHeaderListValues(vs []string) ([]string, error) {
+	return splitHeaderListValues(vs, commaSplit)
+}
+
+func commaSplit(v string) ([]string, error) {
+	return strings.Split(v, ","), nil
+}
+
+// SplitHTTPDateTimestampHeaderListValues attempts to split the HTTP-Date
+// timestamp values in the slice by commas, and return a list of all values
+// separated. The split is aware of HTTP-Date timestamp format, and will skip
+// comma within the timestamp value. Returns an error if unable to split the
+// timestamp values.
+func SplitHTTPDateTimestampHeaderListValues(vs []string) ([]string, error) {
+	return splitHeaderListValues(vs, splitHTTPDateHeaderValue)
+}
+
+func splitHTTPDateHeaderValue(v string) ([]string, error) {
+	if n := strings.Count(v, ","); n == 1 {
+		// Skip values with only a single HTTPDate value
+		return nil, nil
+	} else if n == 0 || n%2 == 0 {
+		return nil, fmt.Errorf("invalid timestamp HTTPDate header comma separations, %q", v)
+	}
+
+	var parts []string
+	var i, j int
+
+	var doSplit bool
+	for ; i < len(v); i++ {
+		if v[i] == ',' {
+			if doSplit {
+				doSplit = false
+				parts = append(parts, v[j:i])
+				j = i + 1
+			} else {
+				// Skip the first comma in the timestamp value since that
+				// separates the day from the rest of the timestamp.
+				//
+				// Tue, 17 Dec 2019 23:48:18 GMT
+				doSplit = true
+			}
+		}
+	}
+	if j < len(v) {
+		parts = append(parts, v[j:])
+	}
+
+	return parts, nil
+}

--- a/transport/http/headerlist_test.go
+++ b/transport/http/headerlist_test.go
@@ -1,0 +1,141 @@
+package http
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSplitHeaderListValues(t *testing.T) {
+	cases := map[string]struct {
+		Values []string
+		Expect []string
+	}{
+		"no split": {
+			Values: []string{
+				"abc", "123", "hello",
+			},
+			Expect: []string{
+				"abc", "123", "hello",
+			},
+		},
+		"with split": {
+			Values: []string{
+				"a, b, c, 1, 2, 3",
+			},
+			Expect: []string{
+				"a", "b", "c", "1", "2", "3",
+			},
+		},
+		"mixed with split": {
+			Values: []string{
+				"abc", "1, 23", "hello,world",
+			},
+			Expect: []string{
+				"abc", "1", "23", "hello", "world",
+			},
+		},
+		"empty values": {
+			Values: []string{
+				"", "1, 23", "hello,world",
+			},
+			Expect: []string{
+				"", "1", "23", "hello", "world",
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := SplitHeaderListValues(c.Values)
+			if err != nil {
+				t.Fatalf("expect no error, %v", err)
+			}
+
+			if diff := cmp.Diff(c.Expect, actual); len(diff) != 0 {
+				t.Errorf("expect values to match\n,%s", diff)
+			}
+		})
+	}
+}
+
+func TestSplitHTTPDateTimestampHeaderListValues(t *testing.T) {
+	cases := map[string]struct {
+		Values    []string
+		Expect    []string
+		ExpectErr string
+	}{
+		"no split": {
+			Values: []string{
+				"Mon, 16 Dec 2019 23:48:18 GMT",
+			},
+			Expect: []string{
+				"Mon, 16 Dec 2019 23:48:18 GMT",
+			},
+		},
+		"with split": {
+			Values: []string{
+				"Mon, 16 Dec 2019 23:48:18 GMT, Tue, 17 Dec 2019 23:48:18 GMT",
+			},
+			Expect: []string{
+				"Mon, 16 Dec 2019 23:48:18 GMT",
+				"Tue, 17 Dec 2019 23:48:18 GMT",
+			},
+		},
+		"mixed with split": {
+			Values: []string{
+				"Sun, 15 Dec 2019 23:48:18 GMT",
+				"Mon, 16 Dec 2019 23:48:18 GMT, Tue, 17 Dec 2019 23:48:18 GMT",
+				"Wed, 18 Dec 2019 23:48:18 GMT",
+			},
+			Expect: []string{
+				"Sun, 15 Dec 2019 23:48:18 GMT",
+				"Mon, 16 Dec 2019 23:48:18 GMT",
+				"Tue, 17 Dec 2019 23:48:18 GMT",
+				"Wed, 18 Dec 2019 23:48:18 GMT",
+			},
+		},
+		"empty values": {
+			Values: []string{
+				"",
+				"Mon, 16 Dec 2019 23:48:18 GMT, Tue, 17 Dec 2019 23:48:18 GMT",
+				"Wed, 18 Dec 2019 23:48:18 GMT",
+			},
+			Expect: []string{
+				"",
+				"Mon, 16 Dec 2019 23:48:18 GMT",
+				"Tue, 17 Dec 2019 23:48:18 GMT",
+				"Wed, 18 Dec 2019 23:48:18 GMT",
+			},
+		},
+		"bad format": {
+			Values: []string{
+				"Mon, 16 Dec 2019 23:48:18 GMT, , Tue, 17 Dec 2019 23:48:18 GMT",
+			},
+			ExpectErr: "invalid timestamp",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := SplitHTTPDateTimestampHeaderListValues(c.Values)
+			if len(c.ExpectErr) != 0 {
+				if err == nil {
+					t.Fatalf("expect error, got none")
+				}
+				if e, a := c.ExpectErr, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect error to contain %v, got %v", e, a)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			if diff := cmp.Diff(c.Expect, actual); len(diff) != 0 {
+				t.Errorf("expect values to match\n,%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds support for the HTTP Date timestamp format shapes within header lists, and header prefix lists. Updates the deserialize codegen to split header list values on comma separated values.

Update deserialize header codegen to use member shape instead of target shape


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
