### PR TITLE
Update smithy-go Go module hash

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -107,6 +107,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200723171755-012806b992a2";
+        private static final String SMITHY_GO = "v0.0.0-20200805220509-75306686f16c";
     }
 }


### PR DESCRIPTION
Fixes the smithy-go module hash that was missed in #125 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
