### PR TITLE
Add Go tip and Go 1.15 to CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,12 @@ matrix:
     - language: go
       go: 1.14.x
       script: go test -v ./...
+
+    - language: go
+      go: 1.15.x
+      script: go test -v ./...
+
+  allow_failures:
+    - language: go
+      go: tip
+      script: go test -v ./...


### PR DESCRIPTION
Updates Travis CI tests to include Go 1.15.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
