### PR TITLE
Adds Step HandlerFunc types that allow wrapping functions to satisfy a step middleware's HandlerFunc interface

### DIFF
--- a/middleware/step_build.go
+++ b/middleware/step_build.go
@@ -187,3 +187,5 @@ type BuildHandlerFunc func(context.Context, BuildInput) (BuildOutput, Metadata, 
 func (b BuildHandlerFunc) HandleBuild(ctx context.Context, in BuildInput) (BuildOutput, Metadata, error) {
 	return b(ctx, in)
 }
+
+var _ BuildHandler = BuildHandlerFunc(nil)

--- a/middleware/step_build.go
+++ b/middleware/step_build.go
@@ -179,3 +179,11 @@ func (h decoratedBuildHandler) HandleBuild(ctx context.Context, in BuildInput) (
 	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleBuild(ctx, in, h.Next)
 }
+
+// BuildHandlerFunc provides a wrapper around a function to be used as a build middleware handler.
+type BuildHandlerFunc func(context.Context, BuildInput) (BuildOutput, Metadata, error)
+
+// HandleBuild invokes the wrapped function with the provided arguments.
+func (b BuildHandlerFunc) HandleBuild(ctx context.Context, in BuildInput) (BuildOutput, Metadata, error) {
+	return b(ctx, in)
+}

--- a/middleware/step_deserialize.go
+++ b/middleware/step_deserialize.go
@@ -195,3 +195,5 @@ type DeserializeHandlerFunc func(context.Context, DeserializeInput) (Deserialize
 func (d DeserializeHandlerFunc) HandleDeserialize(ctx context.Context, in DeserializeInput) (DeserializeOutput, Metadata, error) {
 	return d(ctx, in)
 }
+
+var _ DeserializeHandler = DeserializeHandlerFunc(nil)

--- a/middleware/step_deserialize.go
+++ b/middleware/step_deserialize.go
@@ -187,3 +187,11 @@ func (h decoratedDeserializeHandler) HandleDeserialize(ctx context.Context, in D
 	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleDeserialize(ctx, in, h.Next)
 }
+
+// DeserializeHandlerFunc provides a wrapper around a function to be used as a deserialize middleware handler.
+type DeserializeHandlerFunc func(context.Context, DeserializeInput) (DeserializeOutput, Metadata, error)
+
+// HandleDeserialize invokes the wrapped function with the given arguments.
+func (d DeserializeHandlerFunc) HandleDeserialize(ctx context.Context, in DeserializeInput) (DeserializeOutput, Metadata, error) {
+	return d(ctx, in)
+}

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -181,3 +181,11 @@ func (h decoratedFinalizeHandler) HandleFinalize(ctx context.Context, in Finaliz
 	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleFinalize(ctx, in, h.Next)
 }
+
+// FinalizeHandlerFunc provides a wrapper around a function to be used as a finalize middleware handler.
+type FinalizeHandlerFunc func(ctx context.Context, in FinalizeInput) (FinalizeOutput, Metadata, error)
+
+// HandleFinalize invokes the wrapped function with the given arguments.
+func (f FinalizeHandlerFunc) HandleFinalize(ctx context.Context, in FinalizeInput) (FinalizeOutput, Metadata, error) {
+	return f(ctx, in)
+}

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -189,3 +189,5 @@ type FinalizeHandlerFunc func(context.Context, FinalizeInput) (FinalizeOutput, M
 func (f FinalizeHandlerFunc) HandleFinalize(ctx context.Context, in FinalizeInput) (FinalizeOutput, Metadata, error) {
 	return f(ctx, in)
 }
+
+var _ FinalizeHandler = FinalizeHandlerFunc(nil)

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -183,7 +183,7 @@ func (h decoratedFinalizeHandler) HandleFinalize(ctx context.Context, in Finaliz
 }
 
 // FinalizeHandlerFunc provides a wrapper around a function to be used as a finalize middleware handler.
-type FinalizeHandlerFunc func(ctx context.Context, in FinalizeInput) (FinalizeOutput, Metadata, error)
+type FinalizeHandlerFunc func(context.Context, FinalizeInput) (FinalizeOutput, Metadata, error)
 
 // HandleFinalize invokes the wrapped function with the given arguments.
 func (f FinalizeHandlerFunc) HandleFinalize(ctx context.Context, in FinalizeInput) (FinalizeOutput, Metadata, error) {

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -183,7 +183,7 @@ func (h decoratedInitializeHandler) HandleInitialize(ctx context.Context, in Ini
 }
 
 // InitializeHandlerFunc provides a wrapper around a function to be used as an initialize middleware handler.
-type InitializeHandlerFunc func(ctx context.Context, in InitializeInput) (InitializeOutput, Metadata, error)
+type InitializeHandlerFunc func(context.Context, InitializeInput) (InitializeOutput, Metadata, error)
 
 // HandleInitialize calls the wrapped function with the provided arguments.
 func (i InitializeHandlerFunc) HandleInitialize(ctx context.Context, in InitializeInput) (InitializeOutput, Metadata, error) {

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -189,3 +189,5 @@ type InitializeHandlerFunc func(context.Context, InitializeInput) (InitializeOut
 func (i InitializeHandlerFunc) HandleInitialize(ctx context.Context, in InitializeInput) (InitializeOutput, Metadata, error) {
 	return i(ctx, in)
 }
+
+var _ InitializeHandler = InitializeHandlerFunc(nil)

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -181,3 +181,11 @@ func (h decoratedInitializeHandler) HandleInitialize(ctx context.Context, in Ini
 	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleInitialize(ctx, in, h.Next)
 }
+
+// InitializeHandlerFunc provides a wrapper around a function to be used as an initialize middleware handler.
+type InitializeHandlerFunc func(ctx context.Context, in InitializeInput) (InitializeOutput, Metadata, error)
+
+// HandleInitialize calls the wrapped function with the provided arguments.
+func (i InitializeHandlerFunc) HandleInitialize(ctx context.Context, in InitializeInput) (InitializeOutput, Metadata, error) {
+	return i(ctx, in)
+}

--- a/middleware/step_serialize.go
+++ b/middleware/step_serialize.go
@@ -197,3 +197,5 @@ type SerializeHandlerFunc func(context.Context, SerializeInput) (SerializeOutput
 func (s SerializeHandlerFunc) HandleSerialize(ctx context.Context, in SerializeInput) (SerializeOutput, Metadata, error) {
 	return s(ctx, in)
 }
+
+var _ SerializeHandler = SerializeHandlerFunc(nil)

--- a/middleware/step_serialize.go
+++ b/middleware/step_serialize.go
@@ -189,3 +189,11 @@ func (h decoratedSerializeHandler) HandleSerialize(ctx context.Context, in Seria
 	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleSerialize(ctx, in, h.Next)
 }
+
+// SerializeHandlerFunc provides a wrapper around a function to be used as a serialize middleware handler.
+type SerializeHandlerFunc func(context.Context, SerializeInput) (SerializeOutput, Metadata, error)
+
+// HandleSerialize calls the wrapped function with the provided arguments.
+func (s SerializeHandlerFunc) HandleSerialize(ctx context.Context, in SerializeInput) (SerializeOutput, Metadata, error) {
+	return s(ctx, in)
+}

--- a/transport/http/middleware_content_length_test.go
+++ b/transport/http/middleware_content_length_test.go
@@ -55,7 +55,7 @@ func TestContentLengthMiddleware(t *testing.T) {
 			var m ContentLengthMiddleware
 			_, _, err = m.HandleBuild(context.Background(),
 				middleware.BuildInput{Request: req},
-				nopBuildHandler{},
+				nopBuildHandler,
 			)
 			if len(c.ExpectErr) != 0 {
 				if err == nil {
@@ -93,7 +93,7 @@ func TestContentLengthMiddleware_HeaderSet(t *testing.T) {
 	var m ContentLengthMiddleware
 	_, _, err = m.HandleBuild(context.Background(),
 		middleware.BuildInput{Request: req},
-		nopBuildHandler{},
+		nopBuildHandler,
 	)
 	if err != nil {
 		t.Fatalf("expect middleware to run, %v", err)
@@ -104,13 +104,10 @@ func TestContentLengthMiddleware_HeaderSet(t *testing.T) {
 	}
 }
 
-type nopBuildHandler struct{}
-
-func (nopBuildHandler) HandleBuild(ctx context.Context, in middleware.BuildInput) (
-	out middleware.BuildOutput, metadata middleware.Metadata, err error,
-) {
+var nopBuildHandler = middleware.BuildHandlerFunc(func(ctx context.Context, input middleware.BuildInput) (
+	out middleware.BuildOutput, metadata middleware.Metadata, err error) {
 	return out, metadata, nil
-}
+})
 
 type basicReader struct {
 	buf []byte


### PR DESCRIPTION
Adds Step HandlerFunc types that allow wrapping functions to satisfy a step middleware's HandlerFunc interface.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
