### PR TITLE
Don't cast to middleware type if failed to retrieve ID

### DIFF
--- a/middleware/step_build.go
+++ b/middleware/step_build.go
@@ -116,6 +116,9 @@ func (s *BuildStep) HandleMiddleware(ctx context.Context, in interface{}, next H
 // Get retrieves the middleware identified by id. If the middleware is not present, returns false.
 func (s *BuildStep) Get(id string) (BuildMiddleware, bool) {
 	get, ok := s.ids.Get(id)
+	if !ok {
+		return nil, false
+	}
 	return get.(BuildMiddleware), ok
 }
 

--- a/middleware/step_deserialize.go
+++ b/middleware/step_deserialize.go
@@ -124,6 +124,9 @@ func (s *DeserializeStep) HandleMiddleware(ctx context.Context, in interface{}, 
 // Get retrieves the middleware identified by id. If the middleware is not present, returns false.
 func (s *DeserializeStep) Get(id string) (DeserializeMiddleware, bool) {
 	get, ok := s.ids.Get(id)
+	if !ok {
+		return nil, false
+	}
 	return get.(DeserializeMiddleware), ok
 }
 

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -118,6 +118,9 @@ func (s *FinalizeStep) HandleMiddleware(ctx context.Context, in interface{}, nex
 // Get retrieves the middleware identified by id. If the middleware is not present, returns false.
 func (s *FinalizeStep) Get(id string) (FinalizeMiddleware, bool) {
 	get, ok := s.ids.Get(id)
+	if !ok {
+		return nil, false
+	}
 	return get.(FinalizeMiddleware), ok
 }
 

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -118,6 +118,9 @@ func (s *InitializeStep) HandleMiddleware(ctx context.Context, in interface{}, n
 // Get retrieves the middleware identified by id. If the middleware is not present, returns false.
 func (s *InitializeStep) Get(id string) (InitializeMiddleware, bool) {
 	get, ok := s.ids.Get(id)
+	if !ok {
+		return nil, false
+	}
 	return get.(InitializeMiddleware), ok
 }
 

--- a/middleware/step_serialize.go
+++ b/middleware/step_serialize.go
@@ -126,6 +126,9 @@ func (s *SerializeStep) HandleMiddleware(ctx context.Context, in interface{}, ne
 // Get retrieves the middleware identified by id. If the middleware is not present, returns false.
 func (s *SerializeStep) Get(id string) (SerializeMiddleware, bool) {
 	get, ok := s.ids.Get(id)
+	if !ok {
+		return nil, false
+	}
 	return get.(SerializeMiddleware), ok
 }
 


### PR DESCRIPTION
Don't attempt to cast to the middleware type if a Get returned with no ID found.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
