### PR TITLE
Update unions

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -142,7 +142,7 @@ public final class ShapeValueGenerator {
                         symbol.getNamespace()
                 ).build();
 
-                writer.writeInline("$T{Value: ", memberSymbol);
+                writer.writeInline("&$T{Value: ", memberSymbol);
                 if (target instanceof SimpleShape) {
                     writeScalarValueInline(writer, target, entry.getValue());
                 } else {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -138,7 +138,7 @@ public final class ShapeValueGenerator {
             if (member.isPresent()) {
                 Shape target = model.expectShape(member.get().getTarget());
                 Symbol memberSymbol = SymbolUtils.createValueSymbolBuilder(
-                        String.format("%sMember%s", symbol.getName(), symbolProvider.toMemberName(member.get())),
+                        symbolProvider.toMemberName(member.get()),
                         symbol.getNamespace()
                 ).build();
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -138,7 +138,7 @@ public final class ShapeValueGenerator {
             if (member.isPresent()) {
                 Shape target = model.expectShape(member.get().getTarget());
                 Symbol memberSymbol = SymbolUtils.createValueSymbolBuilder(
-                        symbol.getName() + symbolProvider.toMemberName(member.get()),
+                        String.format("%sMember%s", symbol.getName(), symbolProvider.toMemberName(member.get())),
                         symbol.getNamespace()
                 ).build();
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -385,7 +385,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol unionShape(UnionShape shape) {
         String name = getDefaultShapeName(shape);
-        return SymbolUtils.createPointableSymbolBuilder(shape, name, typesPackageName)
+        return SymbolUtils.createValueSymbolBuilder(shape, name, typesPackageName)
                 .definitionFile("./types/types.go")
                 .build();
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -73,7 +73,7 @@ public class UnionGenerator implements Runnable {
                 }
             });
 
-            writer.write("func ($L) is$L() {}", exportedMemberName, symbol.getName());
+            writer.write("func (*$L) is$L() {}", exportedMemberName, symbol.getName());
         }
 
         // Creates a fallback type for use when an unknown member is found. This
@@ -88,6 +88,6 @@ public class UnionGenerator implements Runnable {
             writer.write("Value []byte");
         });
 
-        writer.write("func (v $L) is$L() {}", unknownStructName, symbol.getName());
+        writer.write("func (*$L) is$L() {}", unknownStructName, symbol.getName());
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -55,7 +55,8 @@ public class UnionGenerator implements Runnable {
         // Create structs for each member that satisfy the interface.
         for (MemberShape member : shape.getAllMembers().values()) {
             Symbol memberSymbol = symbolProvider.toSymbol(member);
-            String exportedMemberName = symbol.getName() + symbolProvider.toMemberName(member);
+            String exportedMemberName = String.format(
+                    "%sMember%s", symbol.getName(), symbolProvider.toMemberName(member));
             Shape target = model.expectShape(member.getTarget());
 
             // Create the member's concrete type

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -57,8 +57,7 @@ public class UnionGenerator implements Runnable {
         // Create structs for each member that satisfy the interface.
         for (MemberShape member : shape.getAllMembers().values()) {
             Symbol memberSymbol = symbolProvider.toSymbol(member);
-            String exportedMemberName = String.format(
-                    "%sMember%s", symbol.getName(), symbolProvider.toMemberName(member));
+            String exportedMemberName = symbolProvider.toMemberName(member);
             Shape target = model.expectShape(member.getTarget());
 
             // Create the member's concrete type

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -164,12 +164,12 @@ public final class ProtocolUtils {
     }
 
     /**
-     * Determines whether a given shape will use a pointer when the shape is used as a union value.
+     * Determines whether a given shape will use a scalar when the shape is used as a union value.
      *
      * @param shape the shape to check
-     * @return true if the shape should use pointers
+     * @return false if the shape should use pointers
      */
-    public static boolean usesPointerWhenUnionValue(Shape shape) {
+    public static boolean usesScalarWhenUnionValue(Shape shape) {
         return !(shape instanceof SimpleShape) || shape.isBlobShape() || shape.hasTrait(EnumTrait.class)
                 || shape.hasTrait(StreamingTrait.class);
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -30,8 +30,10 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.SetUtils;
 
 /**
@@ -159,5 +161,16 @@ public final class ProtocolUtils {
         context.getWriter().openBlock("if $L {", "}", conditionCheck, () -> {
             consumer.accept(operand);
         });
+    }
+
+    /**
+     * Determines whether a given shape will use a pointer when the shape is used as a union value.
+     *
+     * @param shape the shape to check
+     * @return true if the shape should use pointers
+     */
+    public static boolean usesPointerWhenUnionValue(Shape shape) {
+        return !(shape instanceof SimpleShape) || shape.isBlobShape() || shape.hasTrait(EnumTrait.class)
+                || shape.hasTrait(StreamingTrait.class);
     }
 }


### PR DESCRIPTION
This updates generated unions. Now there will only be a single parent interface, and each member will only be a struct that implements that interface.

This also adds generation of unions to the protocol test generator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
