### PR TITLE
Fix Content-Length Behavior

### DIFF
--- a/httpbinding/encode.go
+++ b/httpbinding/encode.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
+
+const contentLengthHeader = "Content-Length"
 
 // An Encoder provides encoding of REST URI path, query, and header components
 // of an HTTP request. Can also encode a stream as the payload.
@@ -42,6 +45,17 @@ func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
 func (e *Encoder) Encode(req *http.Request) (*http.Request, error) {
 	req.URL.Path, req.URL.RawPath = string(e.path), string(e.rawPath)
 	req.URL.RawQuery = e.query.Encode()
+
+	// net/http ignores Content-Length header and requires it to be set on http.Request
+	if v := e.header.Get(contentLengthHeader); len(v) > 0 {
+		iv, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		req.ContentLength = iv
+		e.header.Del(contentLengthHeader)
+	}
+
 	req.Header = e.header
 
 	return req, nil

--- a/transport/http/middleware_content_length.go
+++ b/transport/http/middleware_content_length.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/awslabs/smithy-go/middleware"
 )
@@ -34,17 +33,11 @@ func (m *ContentLengthMiddleware) HandleBuild(
 		return out, metadata, fmt.Errorf("unknown request type %T", req)
 	}
 
-	// Don't set content length if header is already set.
-	if vs := req.Header.Values("Content-Length"); len(vs) != 0 {
-		return next.HandleBuild(ctx, in)
-	}
-
 	if n, ok, err := req.StreamLength(); err != nil {
 		return out, metadata, fmt.Errorf(
 			"failed getting length of request stream, %w", err)
 	} else if ok && n > 0 {
-		// Only set content-length header when it is a positive value.
-		req.Header.Set("Content-Length", strconv.FormatInt(n, 10))
+		req.ContentLength = n
 	}
 
 	return next.HandleBuild(ctx, in)


### PR DESCRIPTION
Fixes the Content-Length behavior by correctly utilizing the `net/http.Request` member for setting the value. The header value if set directly is ignored by the standard library. This was a regression from the original AWS SDK for Go V1/V2 behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
