### PR TITLE
Fix Content-Length Behavior; Define GoIntegration for ServiceId

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -113,7 +113,7 @@ final class OperationGenerator implements Runnable {
                     writer.openBlock("if err != nil {", "}", () -> {
                         writer.addUseImports(SmithyGoDependency.SMITHY);
                         writer.openBlock("return nil, &smithy.OperationError{", "}", () -> {
-                            writer.write("ClientID: c.ClientID(),");
+                            writer.write("ServiceID: ServiceID,");
                             writer.write("OperationName: \"$T\",", operationSymbol);
                             writer.write("Err: err,");
                         });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -113,7 +113,7 @@ final class OperationGenerator implements Runnable {
                     writer.openBlock("if err != nil {", "}", () -> {
                         writer.addUseImports(SmithyGoDependency.SMITHY);
                         writer.openBlock("return nil, &smithy.OperationError{", "}", () -> {
-                            writer.write("ServiceID: c.ServiceID(),");
+                            writer.write("ClientID: c.ClientID(),");
                             writer.write("OperationName: \"$T\",", operationSymbol);
                             writer.write("Err: err,");
                         });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -26,8 +26,6 @@ import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.traits.StringTrait;
-import software.amazon.smithy.model.traits.TitleTrait;
 
 /**
  * Generates a service client and configuration.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -66,7 +66,7 @@ final class ServiceGenerator implements Runnable {
 
     @Override
     public void run() {
-        String serviceId = CodegenUtils.getDefaultPackageImportName(settings.getModuleName());
+        String serviceId = settings.getService().toString();
         for (GoIntegration integration : integrations) {
             serviceId = integration.processServiceId(settings, model, serviceId);
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -66,12 +66,12 @@ final class ServiceGenerator implements Runnable {
 
     @Override
     public void run() {
-        String clientId = CodegenUtils.getDefaultPackageImportName(settings.getModuleName());
+        String serviceId = CodegenUtils.getDefaultPackageImportName(settings.getModuleName());
         for (GoIntegration integration : integrations) {
-            clientId = integration.processClientId(settings, model, clientId);
+            serviceId = integration.processServiceId(settings, model, serviceId);
         }
 
-        writer.write("const ClientID = $S", clientId);
+        writer.write("const ServiceID = $S", serviceId);
         writer.write("");
 
         Symbol serviceSymbol = symbolProvider.toSymbol(service);
@@ -81,10 +81,6 @@ final class ServiceGenerator implements Runnable {
         });
 
         generateConstructor(serviceSymbol);
-
-        writer.writeDocs("ClientID returns the name of the identifier for the service API.");
-        writer.write("func (c $P) ClientID() string { return ClientID }", serviceSymbol);
-
         generateConfig();
 
         Symbol stackSymbol = SymbolUtils.createPointableSymbolBuilder("Stack", SmithyGoDependency.SMITHY_MIDDLEWARE)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -68,6 +68,14 @@ final class ServiceGenerator implements Runnable {
 
     @Override
     public void run() {
+        String clientId = CodegenUtils.getDefaultPackageImportName(settings.getModuleName());
+        for (GoIntegration integration : integrations) {
+            clientId = integration.processClientId(settings, model, clientId);
+        }
+
+        writer.write("const ClientID = $S", clientId);
+        writer.write("");
+
         Symbol serviceSymbol = symbolProvider.toSymbol(service);
         writer.writeShapeDocs(service);
         writer.openBlock("type $T struct {", "}", serviceSymbol, () -> {
@@ -76,14 +84,8 @@ final class ServiceGenerator implements Runnable {
 
         generateConstructor(serviceSymbol);
 
-        String clientId = CodegenUtils.getDefaultPackageImportName(settings.getModuleName());
-        String clientTitle = service.getTrait(TitleTrait.class).map(StringTrait::getValue).orElse(clientId);
-
-        writer.writeDocs("ServiceID returns the name of the identifier for the service API.");
-        writer.write("func (c $P) ServiceID() string { return $S }", serviceSymbol, clientId);
-
-        writer.writeDocs("ServiceName returns the full service title.");
-        writer.write("func (c $P) ServiceName() string { return $S }", serviceSymbol, clientTitle);
+        writer.writeDocs("ClientID returns the name of the identifier for the service API.");
+        writer.write("func (c $P) ClientID() string { return ClientID }", serviceSymbol);
 
         generateConfig();
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200827001424-5fb68d03f931";
+        private static final String SMITHY_GO = "v0.0.0-20200828203131-02d71b5faa8c";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200828203131-02d71b5faa8c";
+        private static final String SMITHY_GO = "v0.0.0-20200828214850-b1c39f43623b";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -200,7 +200,7 @@ public interface GoIntegration {
      * @param clientId the clientId
      * @return the new clientId
      */
-    default String processClientId(GoSettings settings, Model model, String clientId) {
+    default String processServiceId(GoSettings settings, Model model, String clientId) {
         return clientId;
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -17,8 +17,10 @@ package software.amazon.smithy.go.codegen.integration;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.CodegenUtils;
 import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
@@ -189,5 +191,18 @@ public interface GoIntegration {
      */
     default List<RuntimeClientPlugin> getClientPlugins() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Processes the given ClientId and may return a unmodified, modified, or repacelemt value.
+     *
+     *
+     * @param settings Settings used to generate
+     * @param model model to generate from
+     * @param clientId the clientId
+     * @return the new clientId
+     */
+    default String processClientId(GoSettings settings, Model model, String clientId) {
+        return clientId;
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -17,10 +17,8 @@ package software.amazon.smithy.go.codegen.integration;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
-import software.amazon.smithy.go.codegen.CodegenUtils;
 import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -192,15 +192,14 @@ public interface GoIntegration {
     }
 
     /**
-     * Processes the given ClientId and may return a unmodified, modified, or repacelemt value.
-     *
+     * Processes the given serviceId and may return a unmodified, modified, or replacement value.
      *
      * @param settings Settings used to generate
      * @param model model to generate from
-     * @param clientId the clientId
-     * @return the new clientId
+     * @param serviceId the serviceId
+     * @return the new serviceId
      */
-    default String processServiceId(GoSettings settings, Model model, String clientId) {
-        return clientId;
+    default String processServiceId(GoSettings settings, Model model, String serviceId) {
+        return serviceId;
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseErrorGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseErrorGenerator.java
@@ -131,7 +131,7 @@ public class HttpProtocolUnitTestResponseErrorGenerator extends HttpProtocolUnit
         writer.openBlock("if !errors.As(err, &opErr) {", "}", () -> {
             writer.write("t.Fatalf(\"expect $P operation error, got %T\", err)", errorSymbol);
         });
-        writer.openBlock("if e, a := client.ServiceID(), opErr.Service(); e != a {", "}", () -> {
+        writer.openBlock("if e, a := ServiceID, opErr.Service(); e != a {", "}", () -> {
             writer.write("t.Errorf(\"expect %v operation service name, got %v\", e, a)");
         });
         writer.openBlock("if e, a := $S, opErr.Operation(); e != a {", "}", opSymbol.getName(), () -> {

--- a/errors.go
+++ b/errors.go
@@ -42,13 +42,13 @@ var _ APIError = (*GenericAPIError)(nil)
 // OperationError decorates an underlying error which occurred while invoking
 // an operation with names of the operation and API.
 type OperationError struct {
-	ServiceID     string
+	ClientID      string
 	OperationName string
 	Err           error
 }
 
 // Service returns the name of the API service the error occurred with.
-func (e *OperationError) Service() string { return e.ServiceID }
+func (e *OperationError) Service() string { return e.ClientID }
 
 // Operation returns the name of the API operation the error occurred with.
 func (e *OperationError) Operation() string { return e.OperationName }
@@ -57,7 +57,7 @@ func (e *OperationError) Operation() string { return e.OperationName }
 func (e *OperationError) Unwrap() error { return e.Err }
 
 func (e *OperationError) Error() string {
-	return fmt.Sprintf("operation error %s: %s, %v", e.ServiceID, e.OperationName, e.Err)
+	return fmt.Sprintf("operation error %s: %s, %v", e.ClientID, e.OperationName, e.Err)
 }
 
 // DeserializationError provides a wrapper for and error that occurs during

--- a/errors.go
+++ b/errors.go
@@ -42,13 +42,13 @@ var _ APIError = (*GenericAPIError)(nil)
 // OperationError decorates an underlying error which occurred while invoking
 // an operation with names of the operation and API.
 type OperationError struct {
-	ClientID      string
+	ServiceID     string
 	OperationName string
 	Err           error
 }
 
 // Service returns the name of the API service the error occurred with.
-func (e *OperationError) Service() string { return e.ClientID }
+func (e *OperationError) Service() string { return e.ServiceID }
 
 // Operation returns the name of the API operation the error occurred with.
 func (e *OperationError) Operation() string { return e.OperationName }
@@ -57,7 +57,7 @@ func (e *OperationError) Operation() string { return e.OperationName }
 func (e *OperationError) Unwrap() error { return e.Err }
 
 func (e *OperationError) Error() string {
-	return fmt.Sprintf("operation error %s: %s, %v", e.ClientID, e.OperationName, e.Err)
+	return fmt.Sprintf("operation error %s: %s, %v", e.ServiceID, e.OperationName, e.Err)
 }
 
 // DeserializationError provides a wrapper for and error that occurs during

--- a/httpbinding/encode.go
+++ b/httpbinding/encode.go
@@ -40,7 +40,11 @@ func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
 	return e, nil
 }
 
-// Encode returns a REST protocol encoder for encoding HTTP bindings
+// Encode returns a REST protocol encoder for encoding HTTP bindings.
+//
+// Due net/http requiring `Content-Length` to be specified on the http.Request#ContentLength directly. Encode
+// will look for whether the header is present, and if so will remove it and set the respective value on http.Request.
+//
 // Returns any error if one occurred during encoding.
 func (e *Encoder) Encode(req *http.Request) (*http.Request, error) {
 	req.URL.Path, req.URL.RawPath = string(e.path), string(e.rawPath)

--- a/httpbinding/encode.go
+++ b/httpbinding/encode.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
+
+const contentLengthHeader = "Content-Length"
 
 // An Encoder provides encoding of REST URI path, query, and header components
 // of an HTTP request. Can also encode a stream as the payload.
@@ -42,6 +45,17 @@ func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
 func (e *Encoder) Encode(req *http.Request) (*http.Request, error) {
 	req.URL.Path, req.URL.RawPath = string(e.path), string(e.rawPath)
 	req.URL.RawQuery = e.query.Encode()
+
+	// net/http ignores Content-Length header and requires it to be set on http.Request
+	if v := e.header.Get(contentLengthHeader); len(v) > 0 {
+		iv, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		req.ContentLength = iv
+		e.header.Del(contentLengthHeader)
+	}
+
 	req.Header = e.header
 
 	return req, nil

--- a/transport/http/middleware_content_length.go
+++ b/transport/http/middleware_content_length.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/awslabs/smithy-go/middleware"
 )
@@ -34,17 +33,11 @@ func (m *ContentLengthMiddleware) HandleBuild(
 		return out, metadata, fmt.Errorf("unknown request type %T", req)
 	}
 
-	// Don't set content length if header is already set.
-	if vs := req.Header.Values("Content-Length"); len(vs) != 0 {
-		return next.HandleBuild(ctx, in)
-	}
-
 	if n, ok, err := req.StreamLength(); err != nil {
 		return out, metadata, fmt.Errorf(
 			"failed getting length of request stream, %w", err)
 	} else if ok && n > 0 {
-		// Only set content-length header when it is a positive value.
-		req.Header.Set("Content-Length", strconv.FormatInt(n, 10))
+		req.ContentLength = n
 	}
 
 	return next.HandleBuild(ctx, in)

--- a/transport/http/middleware_content_length.go
+++ b/transport/http/middleware_content_length.go
@@ -33,6 +33,10 @@ func (m *ContentLengthMiddleware) HandleBuild(
 		return out, metadata, fmt.Errorf("unknown request type %T", req)
 	}
 
+	if req.ContentLength > 0 {
+		return next.HandleBuild(ctx, in)
+	}
+
 	if n, ok, err := req.StreamLength(); err != nil {
 		return out, metadata, fmt.Errorf(
 			"failed getting length of request stream, %w", err)

--- a/transport/http/middleware_content_length_test.go
+++ b/transport/http/middleware_content_length_test.go
@@ -14,21 +14,21 @@ import (
 func TestContentLengthMiddleware(t *testing.T) {
 	cases := map[string]struct {
 		Stream    io.Reader
-		ExpectLen string
+		ExpectLen int64
 		ExpectErr string
 	}{
 		// Cases
 		"bytes.Reader": {
 			Stream:    bytes.NewReader(make([]byte, 10)),
-			ExpectLen: "10",
+			ExpectLen: 10,
 		},
 		"bytes.Buffer": {
 			Stream:    bytes.NewBuffer(make([]byte, 10)),
-			ExpectLen: "10",
+			ExpectLen: 10,
 		},
 		"strings.Reader": {
 			Stream:    strings.NewReader("hello"),
-			ExpectLen: "5",
+			ExpectLen: 5,
 		},
 		"empty stream": {
 			Stream: strings.NewReader(""),
@@ -68,13 +68,8 @@ func TestContentLengthMiddleware(t *testing.T) {
 				t.Fatalf("expect no error, got %v", err)
 			}
 
-			t.Logf("request Content-Length:%v", req.Header.Get("Content-Length"))
-
-			if e, a := c.ExpectLen, req.Header.Get("Content-Length"); e != a {
+			if e, a := c.ExpectLen, req.ContentLength; e != a {
 				t.Errorf("expect %v content-length, got %v", e, a)
-			}
-			if a := req.Header.Values("Content-Length"); len(c.ExpectLen) == 0 && len(a) != 0 {
-				t.Errorf("expect no content-length header, got %v", a)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes the Content-Length behavior by correctly utilizing the net/http.Request member for setting the value. The header value if set directly is ignored by the standard library. This was a regression from the original AWS SDK for Go V1/V2 behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.