### PR TITLE
Add Header Helper Middleware

### DIFF
--- a/transport/http/middleware_headers.go
+++ b/transport/http/middleware_headers.go
@@ -1,0 +1,88 @@
+package http
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/awslabs/smithy-go/middleware"
+)
+
+type headerValue struct {
+	header string
+	value  string
+	append bool
+}
+
+type headerValueHelper struct {
+	headerValues []headerValue
+}
+
+func (h *headerValueHelper) addHeaderValue(value headerValue) {
+	h.headerValues = append(h.headerValues, value)
+}
+
+func (h *headerValueHelper) ID() string {
+	return "headerValueHelper"
+}
+
+func (h *headerValueHelper) HandleBuild(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (out middleware.BuildOutput, metadata middleware.Metadata, err error) {
+	req, ok := in.Request.(*Request)
+	if !ok {
+		return out, metadata, fmt.Errorf("unknown transport type %T", in.Request)
+	}
+
+	for _, value := range h.headerValues {
+		if value.append {
+			req.Header.Add(value.header, value.value)
+		} else {
+			req.Header.Set(value.header, value.value)
+		}
+	}
+
+	return next.HandleBuild(ctx, in)
+}
+
+func getOrAddHeaderValueHelper(stack *middleware.Stack) (*headerValueHelper, error) {
+	id := (*headerValueHelper)(nil).ID()
+	m, ok := stack.Build.Get(id)
+	if !ok {
+		m = &headerValueHelper{}
+		err := stack.Build.Add(m, middleware.After)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	requestUserAgent, ok := m.(*headerValueHelper)
+	if !ok {
+		return nil, fmt.Errorf("%T for %s middleware did not match expected type", m, id)
+	}
+
+	return requestUserAgent, nil
+}
+
+// AddHeaderValue returns a stack mutator that adds the header value pair to header.
+// Appends to any existing values if present.
+func AddHeaderValue(header string, value string) func(stack *middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		helper, err := getOrAddHeaderValueHelper(stack)
+		if err != nil {
+			return err
+		}
+		helper.addHeaderValue(headerValue{header: header, value: value, append: true})
+		return nil
+	}
+}
+
+// SetHeaderValue returns a stack mutator that adds the header value pair to header.
+// Replaces any existing values if present.
+func SetHeaderValue(header string, value string) func(stack *middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		helper, err := getOrAddHeaderValueHelper(stack)
+		if err != nil {
+			return err
+		}
+		helper.addHeaderValue(headerValue{header: header, value: value, append: false})
+		return nil
+	}
+}

--- a/transport/http/middleware_headers_test.go
+++ b/transport/http/middleware_headers_test.go
@@ -1,0 +1,68 @@
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/awslabs/smithy-go/middleware"
+	smithyhttp "github.com/awslabs/smithy-go/transport/http"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAddHeaderValue(t *testing.T) {
+	stack := middleware.NewStack("stack", smithyhttp.NewStackRequest)
+	err := smithyhttp.AddHeaderValue("foo", "fooValue")(stack)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	err = smithyhttp.AddHeaderValue("bar", "firstValue")(stack)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	err = smithyhttp.AddHeaderValue("bar", "secondValue")(stack)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	handler := middleware.DecorateHandler(middleware.HandlerFunc(func(ctx context.Context, input interface{}) (output interface{}, metadata middleware.Metadata, err error) {
+		req := input.(*smithyhttp.Request)
+		if diff := cmp.Diff(req.Header, http.Header{
+			"Foo": []string{"fooValue"},
+			"Bar": []string{"firstValue", "secondValue"},
+		}); len(diff) > 0 {
+			t.Errorf(diff)
+		}
+		return output, metadata, err
+	}), stack)
+	_, _, err = handler.Handle(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+}
+
+func TestSetHeaderValue(t *testing.T) {
+	stack := middleware.NewStack("stack", smithyhttp.NewStackRequest)
+	err := smithyhttp.SetHeaderValue("foo", "firstValue")(stack)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	err = smithyhttp.SetHeaderValue("foo", "secondValue")(stack)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	handler := middleware.DecorateHandler(middleware.HandlerFunc(func(ctx context.Context, input interface{}) (output interface{}, metadata middleware.Metadata, err error) {
+		req := input.(*smithyhttp.Request)
+		if diff := cmp.Diff(req.Header, http.Header{
+			"Foo": []string{"secondValue"},
+		}); len(diff) > 0 {
+			t.Errorf(diff)
+		}
+		return output, metadata, err
+	}), stack)
+	_, _, err = handler.Handle(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+}


### PR DESCRIPTION
Adds `AddHeaderValue` and `SetHeaderValue` stack mutators that allow easy manipulation of HTTP request headers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
