### PR TITLE
 Fix Insert After relative ordering, added unit tests

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200828214850-b1c39f43623b";
+        private static final String SMITHY_GO = "v0.0.0-20200831191241-f0896471bee5";
     }
 }

--- a/middleware/ordered_group.go
+++ b/middleware/ordered_group.go
@@ -107,6 +107,14 @@ func (g *orderedIDs) Remove(id string) error {
 	return nil
 }
 
+func (g *orderedIDs) List() []string {
+	items := g.order.List()
+	order := make([]string, len(items))
+	copy(order, items)
+
+	return order
+}
+
 // Clear removes all entries.
 func (g *orderedIDs) Clear() {
 	g.order.Clear()
@@ -115,7 +123,7 @@ func (g *orderedIDs) Clear() {
 
 // GetOrder returns the item in the order it should be invoked in.
 func (g *orderedIDs) GetOrder() []interface{} {
-	order := g.order.GetOrder()
+	order := g.order.List()
 	ordered := make([]interface{}, len(order))
 	for i := 0; i < len(order); i++ {
 		ordered[i] = g.items[order[i]]
@@ -191,6 +199,10 @@ func (s *relativeOrder) Remove(id string) error {
 	return nil
 }
 
+func (s *relativeOrder) List() []string {
+	return s.order
+}
+
 func (s *relativeOrder) Clear() {
 	s.order = s.order[0:0]
 }
@@ -203,7 +215,11 @@ func (s *relativeOrder) insert(i int, id string, pos RelativePosition) error {
 		s.order[i] = id
 
 	case After:
-		s.order = append(s.order, id)
+		if i == len(s.order)-1 {
+			s.order = append(s.order, id)
+		} else {
+			s.order = append(s.order[:i+1], append([]string{id}, s.order[i+1:]...)...)
+		}
 
 	default:
 		return fmt.Errorf("invalid position, %v", int(pos))
@@ -219,12 +235,4 @@ func (s *relativeOrder) has(id string) (i int, found bool) {
 		}
 	}
 	return 0, false
-}
-
-// GetOrder returns the order of the item.
-func (s *relativeOrder) GetOrder() []string {
-	order := make([]string, len(s.order))
-	copy(order, s.order)
-
-	return order
 }

--- a/middleware/ordered_group_test.go
+++ b/middleware/ordered_group_test.go
@@ -1,0 +1,192 @@
+package middleware
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOrderedIDsAdd(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Add(mockIder("second"), After))
+	noError(t, o.Add(mockIder("third"), After))
+	noError(t, o.Add(mockIder("real-first"), Before))
+
+	if err := o.Add(mockIder(""), After); err == nil {
+		t.Errorf("expect error adding empty ID, got none")
+	}
+	if err := o.Add(mockIder("second"), After); err == nil {
+		t.Errorf("expect error adding duplicate, got none")
+	}
+	if err := o.Add(mockIder("unique"), 123); err == nil {
+		t.Errorf("expect error add unknown relative position, got none")
+	}
+
+	expectIDs := []string{"real-first", "first", "second", "third"}
+
+	if e, a := expectIDs, o.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v order, got %v", e, a)
+	}
+}
+
+func TestOrderedIDsInsert(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Insert(mockIder("third"), "first", After))
+	noError(t, o.Insert(mockIder("second"), "third", Before))
+	noError(t, o.Insert(mockIder("real-first"), "first", Before))
+	noError(t, o.Insert(mockIder("not-yet-last"), "second", After))
+	noError(t, o.Insert(mockIder("last"), "third", After))
+
+	if err := o.Insert(mockIder(""), "first", After); err == nil {
+		t.Errorf("expect error insert empty ID, got none")
+	}
+	if err := o.Insert(mockIder("second"), "", After); err == nil {
+		t.Errorf("expect error insert with empty relative ID, got none")
+	}
+	if err := o.Insert(mockIder("second"), "third", After); err == nil {
+		t.Errorf("expect error insert duplicate, got none")
+	}
+	if err := o.Insert(mockIder("unique"), "not-found", After); err == nil {
+		t.Errorf("expect error insert not found relative ID, got none")
+	}
+	if err := o.Insert(mockIder("unique"), "first", 123); err == nil {
+		t.Errorf("expect error insert unknown relative position, got none")
+	}
+
+	expectIDs := []string{"real-first", "first", "second", "not-yet-last", "third", "last"}
+	if e, a := expectIDs, o.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v order, got %v", e, a)
+	}
+}
+
+func TestOrderedIDsGet(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Add(mockIder("second"), After))
+
+	f, ok := o.Get("not-found")
+	if ok || f != nil {
+		t.Fatalf("expect id not to be found, but was")
+	}
+
+	f, ok = o.Get("first")
+	if !ok {
+		t.Fatalf("expect id to be found, was not")
+	}
+	if e, a := "first", f.ID(); e != a {
+		t.Errorf("expect %v id, got %v", e, a)
+	}
+}
+
+func TestOrderedIDsSwap(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Add(mockIder("second"), After))
+	noError(t, o.Add(mockIder("third"), After))
+
+	if _, err := o.Swap("first", mockIder("")); err == nil {
+		t.Errorf("expect error swap empty ID, got none")
+	}
+	if _, err := o.Swap("", mockIder("second")); err == nil {
+		t.Errorf("expect error swap with empty relative ID, got none")
+	}
+
+	if _, err := o.Swap("not-exists", mockIder("last")); err == nil {
+		t.Errorf("expect error swap not-exists ID, got none")
+	}
+	if _, err := o.Swap("second", mockIder("first")); err == nil {
+		t.Errorf("expect error swap to existing ID, got none")
+	}
+
+	r, err := o.Swap("second", mockIder("otherSecond"))
+	noError(t, err)
+	if r == nil {
+		t.Fatalf("expect removed item to be returned")
+	}
+	if e, a := "second", r.ID(); e != a {
+		t.Errorf("expect %v removed ider, got %v", e, a)
+	}
+
+	expectIDs := []string{"first", "otherSecond", "third"}
+	if e, a := expectIDs, o.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v order, got %v", e, a)
+	}
+}
+
+func TestOrderedIDsRemove(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Insert(mockIder("third"), "first", After))
+	noError(t, o.Remove("first"))
+	noError(t, o.Insert(mockIder("last"), "third", After))
+
+	if err := o.Remove(""); err == nil {
+		t.Errorf("expect error remove empty ID, got none")
+	}
+	if err := o.Remove("not-exists"); err == nil {
+		t.Errorf("expect error remove not exists ID, got none")
+	}
+
+	expectIDs := []string{"third", "last"}
+	if e, a := expectIDs, o.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v order, got %v", e, a)
+	}
+}
+
+func TestOrderedIDsClear(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Add(mockIder("second"), After))
+
+	o.Clear()
+
+	noError(t, o.Add(mockIder("third"), After))
+	noError(t, o.Add(mockIder("fourth"), After))
+
+	expectIDs := []string{"third", "fourth"}
+	if e, a := expectIDs, o.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v order, got %v", e, a)
+	}
+}
+
+func TestOrderedIDsGetOrder(t *testing.T) {
+	o := newOrderedIDs()
+
+	noError(t, o.Add(mockIder("first"), After))
+	noError(t, o.Add(mockIder("second"), After))
+	noError(t, o.Add(mockIder("third"), After))
+	noError(t, o.Add(mockIder("real-first"), Before))
+
+	expectIDs := []string{"real-first", "first", "second", "third"}
+	if e, a := expectIDs, o.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v order, got %v", e, a)
+	}
+
+	actualOrder := o.GetOrder()
+
+	if e, a := len(expectIDs), len(actualOrder); e != a {
+		t.Errorf("expect %v IDs, got %v", e, a)
+	}
+
+	for _, eID := range expectIDs {
+		var found bool
+		for _, aIder := range actualOrder {
+			if e, a := eID, aIder.(ider).ID(); e == a {
+				if found {
+					t.Errorf("expect only one %v, got more", e)
+				}
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expect to find %v, did not", eID)
+		}
+	}
+}

--- a/middleware/shared_test.go
+++ b/middleware/shared_test.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+)
+
+type mockIder string
+
+func (m mockIder) ID() string { return string(m) }
+
+func noError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+}
+
+func mockInitializeMiddleware(id string) InitializeMiddleware {
+	return InitializeMiddlewareFunc(id,
+		func(
+			ctx context.Context, in InitializeInput, next InitializeHandler,
+		) (
+			out InitializeOutput, metadata Metadata, err error,
+		) {
+			return next.HandleInitialize(ctx, in)
+		})
+}
+
+func mockSerializeMiddleware(id string) SerializeMiddleware {
+	return SerializeMiddlewareFunc(id,
+		func(
+			ctx context.Context, in SerializeInput, next SerializeHandler,
+		) (
+			out SerializeOutput, metadata Metadata, err error,
+		) {
+			return next.HandleSerialize(ctx, in)
+		})
+}
+
+func mockBuildMiddleware(id string) BuildMiddleware {
+	return BuildMiddlewareFunc(id,
+		func(
+			ctx context.Context, in BuildInput, next BuildHandler,
+		) (
+			out BuildOutput, metadata Metadata, err error,
+		) {
+			return next.HandleBuild(ctx, in)
+		})
+}
+
+func mockFinalizeMiddleware(id string) FinalizeMiddleware {
+	return FinalizeMiddlewareFunc(id,
+		func(
+			ctx context.Context, in FinalizeInput, next FinalizeHandler,
+		) (
+			out FinalizeOutput, metadata Metadata, err error,
+		) {
+			return next.HandleFinalize(ctx, in)
+		})
+}
+
+func mockDeserializeMiddleware(id string) DeserializeMiddleware {
+	return DeserializeMiddlewareFunc(id,
+		func(
+			ctx context.Context, in DeserializeInput, next DeserializeHandler,
+		) (
+			out DeserializeOutput, metadata Metadata, err error,
+		) {
+			return next.HandleDeserialize(ctx, in)
+		})
+}

--- a/middleware/stack_test.go
+++ b/middleware/stack_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStackList(t *testing.T) {
+	s := NewStack("fooStack", func() interface{} { return struct{}{} })
+
+	s.Initialize.Add(mockInitializeMiddleware("first"), After)
+	s.Serialize.Add(mockSerializeMiddleware("second"), After)
+	s.Build.Add(mockBuildMiddleware("third"), After)
+	s.Finalize.Add(mockFinalizeMiddleware("fourth"), After)
+	s.Deserialize.Add(mockDeserializeMiddleware("fifth"), After)
+
+	actual := s.List()
+
+	expect := []string{
+		"fooStack",
+		(*InitializeStep)(nil).ID(),
+		"first",
+		(*SerializeStep)(nil).ID(),
+		"second",
+		(*BuildStep)(nil).ID(),
+		"third",
+		(*FinalizeStep)(nil).ID(),
+		"fourth",
+		(*DeserializeStep)(nil).ID(),
+		"fifth",
+	}
+
+	if diff := cmp.Diff(expect, actual); len(diff) != 0 {
+		t.Errorf("expect and actual stack list differ\n%s", diff)
+	}
+}
+
+func TestStackString(t *testing.T) {
+	s := NewStack("fooStack", func() interface{} { return struct{}{} })
+
+	s.Initialize.Add(mockInitializeMiddleware("first"), After)
+	s.Serialize.Add(mockSerializeMiddleware("second"), After)
+	s.Build.Add(mockBuildMiddleware("third"), After)
+	s.Finalize.Add(mockFinalizeMiddleware("fourth"), After)
+	s.Deserialize.Add(mockDeserializeMiddleware("fifth"), After)
+
+	actual := s.String()
+
+	expect := strings.Join([]string{
+		"fooStack",
+		"\t" + (*InitializeStep)(nil).ID(),
+		"\t\t" + "first",
+		"\t" + (*SerializeStep)(nil).ID(),
+		"\t\t" + "second",
+		"\t" + (*BuildStep)(nil).ID(),
+		"\t\t" + "third",
+		"\t" + (*FinalizeStep)(nil).ID(),
+		"\t\t" + "fourth",
+		"\t" + (*DeserializeStep)(nil).ID(),
+		"\t\t" + "fifth",
+		"",
+	}, "\n")
+
+	if diff := cmp.Diff(expect, actual); len(diff) != 0 {
+		t.Errorf("expect and actual stack list differ\n%s", diff)
+	}
+}

--- a/middleware/step_build.go
+++ b/middleware/step_build.go
@@ -153,6 +153,11 @@ func (s *BuildStep) Remove(id string) error {
 	return s.ids.Remove(id)
 }
 
+// List returns a list of the middleware in the step.
+func (s *BuildStep) List() []string {
+	return s.ids.List()
+}
+
 // Clear removes all middleware in the step.
 func (s *BuildStep) Clear() {
 	s.ids.Clear()

--- a/middleware/step_deserialize.go
+++ b/middleware/step_deserialize.go
@@ -161,6 +161,11 @@ func (s *DeserializeStep) Remove(id string) error {
 	return s.ids.Remove(id)
 }
 
+// List returns a list of the middleware in the step.
+func (s *DeserializeStep) List() []string {
+	return s.ids.List()
+}
+
 // Clear removes all middleware in the step.
 func (s *DeserializeStep) Clear() {
 	s.ids.Clear()

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -155,6 +155,11 @@ func (s *FinalizeStep) Remove(id string) error {
 	return s.ids.Remove(id)
 }
 
+// List returns a list of the middleware in the step.
+func (s *FinalizeStep) List() []string {
+	return s.ids.List()
+}
+
 // Clear removes all middleware in the step.
 func (s *FinalizeStep) Clear() {
 	s.ids.Clear()

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -155,6 +155,11 @@ func (s *InitializeStep) Remove(id string) error {
 	return s.ids.Remove(id)
 }
 
+// List returns a list of the middleware in the step.
+func (s *InitializeStep) List() []string {
+	return s.ids.List()
+}
+
 // Clear removes all middleware in the step.
 func (s *InitializeStep) Clear() {
 	s.ids.Clear()

--- a/middleware/step_serialize.go
+++ b/middleware/step_serialize.go
@@ -163,6 +163,11 @@ func (s *SerializeStep) Remove(id string) error {
 	return s.ids.Remove(id)
 }
 
+// List returns a list of the middleware in the step.
+func (s *SerializeStep) List() []string {
+	return s.ids.List()
+}
+
 // Clear removes all middleware in the step.
 func (s *SerializeStep) Clear() {
 	s.ids.Clear()


### PR DESCRIPTION
Adds unit tests for the middleware ordering behavior, this discovered abug in the Insert After behavior not correctly inserting within a list. It only inserted after to the end of the list.

Also adds a List method for all middleware step that returns the list of middleware in the step.

Reduce allocations for getting order of middleware when middleware stack is built into handler decorators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
