### PR TITLE
Fix API client generation issues discovered in new model builds

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -170,10 +170,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         return symbolName + "_";
     }
 
-    private String getDefaultShapeName(Shape shape) {
-        return StringUtils.capitalize(shape.getId().getName());
-    }
-
     @Override
     public Symbol toSymbol(Shape shape) {
         Symbol symbol = shape.accept(this);
@@ -221,9 +217,29 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         return String.format("%sMember%s", getDefaultShapeName(union), getDefaultMemberName(member));
     }
 
-    private String getDefaultMemberName(MemberShape shape) {
-        return StringUtils.capitalize(shape.getMemberName());
+    private String getDefaultShapeName(Shape shape) {
+        return StringUtils.capitalize(removeLeadingUnderscores(shape.getId().getName()));
     }
+
+    private String getDefaultMemberName(MemberShape shape) {
+        return StringUtils.capitalize(removeLeadingUnderscores(shape.getMemberName()));
+    }
+
+    private String removeLeadingUnderscores(String value) {
+        if (!value.startsWith("_")) {
+            return value;
+        }
+
+        int i;
+        for (i = 0; i < value.length(); i++) {
+            if (value.charAt(i) != '_') {
+                break;
+            }
+        }
+
+        return value.substring(i);
+    }
+
 
     private boolean isErrorMember(MemberShape shape) {
         return model.getShape(shape.getContainer())

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -207,7 +207,7 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
      * @param service Service for which idempotency token map is retrieved.
      * @return map of operation shapeId as key, member shape as value.
      */
-    private static Map<ShapeId, MemberShape> getOperationsWithIdempotencyToken(Model model, ServiceShape service) {
+    public static Map<ShapeId, MemberShape> getOperationsWithIdempotencyToken(Model model, ServiceShape service) {
         Map<ShapeId, MemberShape> map = new TreeMap<>();
         service.getAllOperations().stream().forEach((operation) -> {
             OperationShape operationShape = model.expectShape(operation).asOperationShape().get();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SyntheticClone;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -155,7 +156,8 @@ public interface ProtocolGenerator {
      *
      * @param context Generation context
      */
-    default void generateProtocolTests(GenerationContext context) {}
+    default void generateProtocolTests(GenerationContext context) {
+    }
 
     /**
      * Generates the name of a serializer function for shapes of a service.
@@ -166,20 +168,7 @@ public interface ProtocolGenerator {
      */
     static String getOperationHttpBindingsSerFunctionName(Shape shape, String protocol) {
         return protocol
-                + "_serializeHttpBindings"
-                + StringUtils.capitalize(shape.getId().getName());
-    }
-
-    /**
-     * Generates the name of a operation document serializer function for shapes of a service.
-     *
-     * @param shape    The shape the serializer function is being generated for.
-     * @param protocol Name of the protocol being generated.
-     * @return Returns the generated function name.
-     */
-    static String getOperationDocumentSerFunctionName(Shape shape, String protocol) {
-        return protocol
-                + "_serializeOpDocument"
+                + "_serializeOpHttpBindings"
                 + StringUtils.capitalize(shape.getId().getName());
     }
 
@@ -192,7 +181,7 @@ public interface ProtocolGenerator {
      */
     static String getOperationHttpBindingsDeserFunctionName(Shape shape, String protocol) {
         return protocol
-                + "_deserializeHttpBindings"
+                + "_deserializeOpHttpBindings"
                 + StringUtils.capitalize(shape.getId().getName());
     }
 
@@ -204,7 +193,11 @@ public interface ProtocolGenerator {
      * @return Returns the generated function name.
      */
     static String getDocumentSerializerFunctionName(Shape shape, String protocol) {
-        return protocol + "_serializeDocument" + StringUtils.capitalize(shape.getId().getName());
+        String extra = "";
+        if (shape.hasTrait(SyntheticClone.class)) {
+            extra = "Op";
+        }
+        return protocol + "_serialize" + extra + "Document" + StringUtils.capitalize(shape.getId().getName());
     }
 
     /**
@@ -215,19 +208,13 @@ public interface ProtocolGenerator {
      * @return Returns the generated function name.
      */
     static String getDocumentDeserializerFunctionName(Shape shape, String protocol) {
-        return protocol + "_deserializeDocument" + StringUtils.capitalize(shape.getId().getName());
+        String extra = "";
+        if (shape.hasTrait(SyntheticClone.class)) {
+            extra = "Op";
+        }
+        return protocol + "_deserialize" + extra + "Document" + StringUtils.capitalize(shape.getId().getName());
     }
 
-    /**
-     * Generates the name of a deserializer function for an output shape of a service.
-     *
-     * @param shape    The shape the deserializer function is being generated for.
-     * @param protocol Name of the protocol being generated.
-     * @return Returns the generated function name.
-     */
-    static String getDocumentOutputDeserializerFunctionName(Shape shape, String protocol) {
-        return protocol + "_deserializeOpDocument" + StringUtils.capitalize(shape.getId().getName());
-    }
 
     static String getOperationErrorDeserFunctionName(OperationShape shape, String protocol) {
         return protocol + "_deserializeOpError" + StringUtils.capitalize(shape.getId().getName());


### PR DESCRIPTION
Fixes issues with the API client codegen that were discovered in the latest set of models added to the SDK.

* Makes idempotency used helper public, needed by https://github.com/aws/aws-sdk-go-v2/pull/708.
* Fixes #166 by removing leading underscores from shape and member names. Since underscore is not a `capital` alphabetic character, making the type or member unexported.
* Fixes #167 by ensuring operation input/output shape (de)serializers are generated with unique name vs modeled shape (de)serializer functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
