### PR TITLE
Performance fixes

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -56,7 +56,6 @@ import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
-import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.OptionalUtils;
 
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -378,8 +378,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the payload serializer logic for the serializer middleware body.
      *
-     * @param context the generation context
-     * @param memberShape    the payload target member
+     * @param context     the generation context
+     * @param memberShape the payload target member
      */
     protected void writeMiddlewarePayloadSerializerDelegator(
             GenerationContext context,
@@ -446,9 +446,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generate the payload serializers with document serializer logic for the serializer middleware body.
      *
-     * @param context the generation context
-     * @param memberShape    the payload target member
-     * @param operand      the operand that is used to access the member value
+     * @param context     the generation context
+     * @param memberShape the payload target member
+     * @param operand     the operand that is used to access the member value
      */
     protected abstract void writeMiddlewarePayloadAsDocumentSerializerDelegator(
             GenerationContext context,
@@ -677,8 +677,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     }
 
                     writer.write("hv := encoder.Headers($S)", getCanonicalHeader(locationName));
+                    writer.addUseImports(SmithyGoDependency.NET_HTTP);
                     writer.openBlock("for mapKey, mapVal := range $L {", "}", operand, () -> {
-                        writeHeaderBinding(context, valueMemberShape, "mapVal", location, "mapKey", "hv");
+                        writeHeaderBinding(context, valueMemberShape, "mapVal", location,
+                                "http.CanonicalHeaderKey(mapKey)", "hv");
                     });
                     break;
                 case LABEL:

--- a/httpbinding/encode.go
+++ b/httpbinding/encode.go
@@ -85,8 +85,8 @@ func (e *Encoder) Headers(prefix string) Headers {
 
 // HasHeader returns if a header with the key specified exists with one more
 // more value.
-func (e Encoder) HasHeader(Key string) bool {
-	return len(e.header.Values(Key)) != 0
+func (e Encoder) HasHeader(key string) bool {
+	return len(e.header[key]) != 0
 }
 
 // SetURI returns a URIValue used for setting the given path key

--- a/httpbinding/encode_test.go
+++ b/httpbinding/encode_test.go
@@ -21,8 +21,8 @@ func TestEncoder(t *testing.T) {
 	expected := &http.Request{
 		Header: map[string][]string{
 			"custom-user-header": {"someValue"},
-			"X-Amzn-Header-Foo":  {"someValue"},
-			"X-Amzn-Meta-Foo":    {"someValue"},
+			"x-amzn-header-foo":  {"someValue"},
+			"x-amzn-meta-foo":    {"someValue"},
 		},
 		URL: &url.URL{
 			Path:     "/some/someValue/path",
@@ -69,7 +69,7 @@ func TestEncoderHasHeader(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if h := "I-dont-exist"; encoder.HasHeader(h) {
+	if h := "i-dont-exist"; encoder.HasHeader(h) {
 		t.Errorf("expect %v not to be set", h)
 	}
 

--- a/httpbinding/header.go
+++ b/httpbinding/header.go
@@ -41,9 +41,9 @@ func newHeaderValue(header http.Header, key string, append bool) HeaderValue {
 
 func (h HeaderValue) modifyHeader(value string) {
 	if h.append {
-		h.header.Add(h.key, value)
+		h.header[h.key] = append(h.header[h.key], value)
 	} else {
-		h.header.Set(h.key, value)
+		h.header[h.key] = append(h.header[h.key][:0], value)
 	}
 }
 

--- a/httpbinding/header_test.go
+++ b/httpbinding/header_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHeaderValue(t *testing.T) {
 	const keyName = "test-key"
-	const expectedKeyName = "Test-Key"
+	const expectedKeyName = "test-key"
 
 	cases := map[string]struct {
 		header   http.Header
@@ -205,7 +205,7 @@ func TestHeaderValue(t *testing.T) {
 }
 
 func TestHeaders(t *testing.T) {
-	const prefix = "x-amzn-meta-"
+	const prefix = "X-Amzn-Meta-"
 	cases := map[string]struct {
 		headers  http.Header
 		values   map[string]string
@@ -217,8 +217,8 @@ func TestHeaders(t *testing.T) {
 				"X-Amzn-Meta-Foo": {"bazValue"},
 			},
 			values: map[string]string{
-				"foo":   "fooValue",
-				" bar ": "barValue",
+				"Foo":   "fooValue",
+				" Bar ": "barValue",
 			},
 			expected: http.Header{
 				"X-Amzn-Meta-Foo": {"fooValue"},
@@ -230,8 +230,8 @@ func TestHeaders(t *testing.T) {
 				"X-Amzn-Meta-Foo": {"bazValue"},
 			},
 			values: map[string]string{
-				"foo":   "fooValue",
-				" bar ": "barValue",
+				"Foo":   "fooValue",
+				" Bar ": "barValue",
 			},
 			append: true,
 			expected: http.Header{

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -54,7 +54,6 @@ type decoratedHandler struct {
 func (m decoratedHandler) Handle(ctx context.Context, input interface{}) (
 	output interface{}, metadata Metadata, err error,
 ) {
-	ctx = RecordMiddleware(ctx, m.With.ID())
 	return m.With.HandleMiddleware(ctx, input, m.Next)
 }
 

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -44,13 +43,11 @@ func mockKeyGet(md MetadataReader, key int) string {
 }
 
 type mockHandler struct {
-	calledMiddleware []string
 }
 
 func (m *mockHandler) Handle(ctx context.Context, input interface{}) (
 	output interface{}, metadata Metadata, err error,
 ) {
-	m.calledMiddleware = GetMiddlewareIDs(ctx)
 	return nil, metadata, nil
 }
 
@@ -66,19 +63,6 @@ func TestDecorateHandler(t *testing.T) {
 	_, metadata, err := h.Handle(context.Background(), struct{}{})
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
-	}
-
-	if e, a := 3, len(mockHandler.calledMiddleware); e != a {
-		t.Errorf("expect %v middleware, got %v", e, a)
-	}
-
-	expect := []string{
-		"mock middleware 0",
-		"mock middleware 1",
-		"mock middleware 2",
-	}
-	if e, a := expect, mockHandler.calledMiddleware; !reflect.DeepEqual(e, a) {
-		t.Errorf("expect:\n%v\nactual:\n%v", e, a)
 	}
 
 	expectMeta := map[int]interface{}{

--- a/middleware/step_build.go
+++ b/middleware/step_build.go
@@ -190,7 +190,6 @@ var _ BuildHandler = (*decoratedBuildHandler)(nil)
 func (h decoratedBuildHandler) HandleBuild(ctx context.Context, in BuildInput) (
 	out BuildOutput, metadata Metadata, err error,
 ) {
-	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleBuild(ctx, in, h.Next)
 }
 

--- a/middleware/step_deserialize.go
+++ b/middleware/step_deserialize.go
@@ -198,7 +198,6 @@ var _ DeserializeHandler = (*decoratedDeserializeHandler)(nil)
 func (h decoratedDeserializeHandler) HandleDeserialize(ctx context.Context, in DeserializeInput) (
 	out DeserializeOutput, metadata Metadata, err error,
 ) {
-	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleDeserialize(ctx, in, h.Next)
 }
 

--- a/middleware/step_finalize.go
+++ b/middleware/step_finalize.go
@@ -192,7 +192,6 @@ var _ FinalizeHandler = (*decoratedFinalizeHandler)(nil)
 func (h decoratedFinalizeHandler) HandleFinalize(ctx context.Context, in FinalizeInput) (
 	out FinalizeOutput, metadata Metadata, err error,
 ) {
-	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleFinalize(ctx, in, h.Next)
 }
 

--- a/middleware/step_initialize.go
+++ b/middleware/step_initialize.go
@@ -192,7 +192,6 @@ var _ InitializeHandler = (*decoratedInitializeHandler)(nil)
 func (h decoratedInitializeHandler) HandleInitialize(ctx context.Context, in InitializeInput) (
 	out InitializeOutput, metadata Metadata, err error,
 ) {
-	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleInitialize(ctx, in, h.Next)
 }
 

--- a/middleware/step_serialize.go
+++ b/middleware/step_serialize.go
@@ -200,7 +200,6 @@ var _ SerializeHandler = (*decoratedSerializeHandler)(nil)
 func (h decoratedSerializeHandler) HandleSerialize(ctx context.Context, in SerializeInput) (
 	out SerializeOutput, metadata Metadata, err error,
 ) {
-	ctx = RecordMiddleware(ctx, h.With.ID())
 	return h.With.HandleSerialize(ctx, in, h.Next)
 }
 

--- a/rand/uuid.go
+++ b/rand/uuid.go
@@ -1,9 +1,11 @@
 package rand
 
 import (
-	"fmt"
+	"encoding/hex"
 	"io"
 )
+
+const dash byte = '-'
 
 // UUIDIdempotencyToken provides a utility to get idempotency tokens in the
 // UUID format.
@@ -54,5 +56,17 @@ func uuidVersion4(u [16]byte) string {
 	// 17th character is "8", "9", "a", or "b"
 	u[8] = (u[8] & 0x3f) | 0x80 // Variant is 10
 
-	return fmt.Sprintf(`%X-%X-%X-%X-%X`, u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+	var scratch [36]byte
+
+	hex.Encode(scratch[:8], u[0:4])
+	scratch[8] = dash
+	hex.Encode(scratch[9:13], u[4:6])
+	scratch[13] = dash
+	hex.Encode(scratch[14:18], u[6:8])
+	scratch[18] = dash
+	hex.Encode(scratch[19:23], u[8:10])
+	scratch[23] = dash
+	hex.Encode(scratch[24:], u[10:])
+
+	return string(scratch[:])
 }

--- a/transport/http/user_agent.go
+++ b/transport/http/user_agent.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -22,7 +21,7 @@ func (u *UserAgentBuilder) AddKey(key string) {
 
 // AddKeyValue adds the named key to the agent string with the given value.
 func (u *UserAgentBuilder) AddKeyValue(key, value string) {
-	u.appendTo(fmt.Sprintf("%s/%s", key, value))
+	u.appendTo(key + "/" + value)
 }
 
 // Build returns the constructed User-Agent string. May be called multiple times.


### PR DESCRIPTION
Makes some small performance fixes my removing the `RecordMiddleware`, removing usage of `fmt.Sprintf`, precomputing canonical headers and setting them directly via the `httpbinding.Encoder`, and moving the `RingBuffer`'s backing slice to the stack.
