### PR TITLE
Add Bytes method to RingBuffer

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200908004534-2685ba1f252f";
+        private static final String SMITHY_GO = "v0.0.0-20200914182735-7f099cf30985";
     }
 }

--- a/io/ringbuffer.go
+++ b/io/ringbuffer.go
@@ -1,6 +1,9 @@
 package io
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // RingBuffer struct satisfies io.ReadWrite interface.
 //
@@ -69,6 +72,13 @@ func (r *RingBuffer) Read(p []byte) (int, error) {
 		}
 	}
 	return readCount, nil
+}
+
+// Bytes returns a copy of the RingBuffer's bytes.
+func (r RingBuffer) Bytes() []byte {
+	var b bytes.Buffer
+	io.Copy(&b, &r)
+	return b.Bytes()
 }
 
 // Reset resets the ring buffer.


### PR DESCRIPTION
Adds a `Bytes` method to the `RingBuffer` to make it easier to retrieve the value of its buffer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
