### PR TITLE
Don't use test server for response tests

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
@@ -158,6 +158,7 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
                     handler.accept(writer);
                 });
         writer.write("defer $L.Close()", name);
+        writer.write("url := server.URL");
     }
 
     /**


### PR DESCRIPTION
This removes the test server for response tests, replacing it with
a simple stubbed HTTP client that returns a pre-canned response.
This is necessary because the test server would inject additional
headers / info that we weren't expecting which would break protocol
tests where we have an expectation on the entire set of headers.

This will need to go along with a PR in the aws repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
