### PR TITLE
A request without a body should not fail request rewind stream

### DIFF
--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -77,6 +77,11 @@ func (r *Request) StreamLength() (size int64, ok bool, err error) {
 // RewindStream will rewind the io.Reader to the relative start position if it
 // is an io.Seeker.
 func (r *Request) RewindStream() error {
+	// If there is no stream there is nothing to rewind.
+	if r.stream == nil {
+		return nil
+	}
+
 	if !r.isStreamSeekable {
 		return fmt.Errorf("request stream is not seekable")
 	}

--- a/transport/http/request_test.go
+++ b/transport/http/request_test.go
@@ -1,0 +1,56 @@
+package http
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestRequestRewindable(t *testing.T) {
+	cases := map[string]struct {
+		Stream    io.Reader
+		ExpectErr string
+	}{
+		"rewindable": {
+			Stream: bytes.NewReader([]byte{}),
+		},
+		"not rewindable": {
+			Stream:    bytes.NewBuffer([]byte{}),
+			ExpectErr: "stream is not seekable",
+		},
+		"nil stream": {},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := &Request{
+				Request: &http.Request{
+					URL:    &url.URL{},
+					Header: http.Header{},
+				},
+			}
+
+			req, err := req.SetStream(c.Stream)
+			if err != nil {
+				t.Fatalf("expect no error setting stream, %v", err)
+			}
+
+			err = req.RewindStream()
+			if len(c.ExpectErr) != 0 {
+				if err == nil {
+					t.Fatalf("expect error, got none")
+				}
+				if e, a := c.ExpectErr, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect error to contain %v, got %v", e, a)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates the smithy-go http request type's RewindStream method to not fail if the request does not have a body. The Rewind becomes a no-op. Without this change, nil streams of requests would cause the request's RewindStream method to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
