### PR TITLE
Support endpoint and hostLabel traits

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -16,7 +16,7 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.isShapeWithResponseBindings;
-import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setEndpointPrefix;
+import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setHostPrefix;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.requiresDocumentSerdeFunction;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.writeSafeMemberAccessor;
 
@@ -212,7 +212,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         + " in.Parameters)}");
             });
 
-            setEndpointPrefix(context, operation);
+            setHostPrefix(context, operation);
 
             writer.write("");
             writer.write("opPath, opQuery := httpbinding.SplitURI($S)", httpTrait.getUri());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.isShapeWithResponseBindings;
+import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setEndpointPrefix;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.requiresDocumentSerdeFunction;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.writeSafeMemberAccessor;
 
@@ -210,6 +211,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
                         + " in.Parameters)}");
             });
+
+            setEndpointPrefix(context, operation);
 
             writer.write("");
             writer.write("opPath, opQuery := httpbinding.SplitURI($S)", httpTrait.getUri());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -15,7 +15,7 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
-import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setEndpointPrefix;
+import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setHostPrefix;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -119,7 +119,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                         + " in.Parameters)}");
             }).write("");
 
-            setEndpointPrefix(context, operation);
+            setHostPrefix(context, operation);
 
             writer.write("request.Request.URL.Path = $S", getOperationPath(context, operation));
             writer.write("request.Request.Method = \"POST\"");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setEndpointPrefix;
+
 import java.util.Set;
 import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -116,6 +118,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                         + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
                         + " in.Parameters)}");
             }).write("");
+
+            setEndpointPrefix(context, operation);
 
             writer.write("request.Request.URL.Path = $S", getOperationPath(context, operation));
             writer.write("request.Request.Method = \"POST\"");

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -47,7 +47,12 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 		return nil, metadata, fmt.Errorf("expect Smithy http.Request value as input, got unsupported type %T", input)
 	}
 
-	resp, err := c.client.Do(req.Build(ctx))
+	builtRequest := req.Build(ctx)
+	if err := ValidateEndpointHost(builtRequest.Host); err != nil {
+		return nil, metadata, err
+	}
+
+	resp, err := c.client.Do(builtRequest)
 	if err != nil {
 		return nil, metadata, err
 	}

--- a/transport/http/host.go
+++ b/transport/http/host.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateEndpointHost validates that the host string passed in is a valid RFC
+// 3986 host. Returns error if the host is not valid.
+func ValidateEndpointHost(host string) error {
+	var errors strings.Builder
+	labels := strings.Split(host, ".")
+
+	for i, label := range labels {
+		if i == len(labels)-1 && len(label) == 0 {
+			// Allow trailing dot for FQDN hosts.
+			continue
+		}
+
+		if !ValidHostLabel(label) {
+			errors.WriteString("\nendpoint host domain labels must match \"[a-zA-Z0-9-]{1,63}\", but found: ")
+			errors.WriteString(label)
+		}
+	}
+
+	if len(host) > 255 {
+		errors.WriteString(fmt.Sprintf("\nendpoint host must be less than 255 characters, but was %d", len(host)))
+	}
+
+	if len(errors.String()) > 0 {
+		return fmt.Errorf("invalid endpoint host%s", errors.String())
+	}
+	return nil
+}
+
+// ValidHostLabel returns if the label is a valid RFC 3986 host label.
+func ValidHostLabel(label string) bool {
+	if l := len(label); l == 0 || l > 63 {
+		return false
+	}
+	for _, r := range label {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/transport/http/host_test.go
+++ b/transport/http/host_test.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestValidHostLabel(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{Input: "abc123", Valid: true},
+		{Input: "123", Valid: true},
+		{Input: "abc", Valid: true},
+		{Input: "123-abc", Valid: true},
+		{Input: "{thing}-abc", Valid: false},
+		{Input: "abc.123", Valid: false},
+		{Input: "abc/123", Valid: false},
+		{Input: "012345678901234567890123456789012345678901234567890123456789123", Valid: true},
+		{Input: "0123456789012345678901234567890123456789012345678901234567891234", Valid: false},
+		{Input: "", Valid: false},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			valid := ValidHostLabel(c.Input)
+			if e, a := c.Valid, valid; e != a {
+				t.Errorf("expect valid %v, got %v", e, a)
+			}
+		})
+	}
+}
+
+func TestValidateEndpointHostHandler(t *testing.T) {
+	cases := map[string]struct {
+		Input string
+		Valid bool
+	}{
+		"valid host":  {Input: "abc.123", Valid: true},
+		"fqdn host":   {Input: "abc.123.", Valid: true},
+		"empty label": {Input: "abc..", Valid: false},
+		"max host len": {
+			Input: "123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.12345",
+			Valid: true,
+		},
+		"too long host": {
+			Input: "123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456",
+			Valid: false,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateEndpointHost(c.Input)
+			if e, a := c.Valid, err == nil; e != a {
+				t.Errorf("expect valid %v, got %v, %v", e, a, err)
+			}
+		})
+	}
+}

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -16,6 +16,7 @@ type Request struct {
 	stream           io.Reader
 	isStreamSeekable bool
 	streamStartPos   int64
+	HostPrefix       string
 }
 
 // NewStackRequest returns an initialized request ready to populated with the
@@ -139,6 +140,11 @@ func (r *Request) Build(ctx context.Context) *http.Request {
 
 	if r.stream != nil {
 		req.Body = ioutil.NopCloser(r.stream)
+	}
+
+	// Add the host prefix
+	if len(r.HostPrefix) != 0 {
+		req.URL.Host = r.HostPrefix + req.URL.Host
 	}
 
 	return req


### PR DESCRIPTION
This adds support for the endpoint and hostLabel traits. This is
accomplished by adding a `HostPrefix` member to the Smithy Request
struct, which is prepended to the host when the underlying http
Request is finalized.

If there are no labels, the host prefix is simply generated as a
a string that is set on the smithy request like so:

```go
request.HostPrefix = "data-"
```

If there are labels, a string builder is used:

```go
var prefix strings.Builder
prefix.WriteString("data-")
if input.ServiceName == nil {
	return out, metadata, &smithy.SerializationError{Err: fmt.Errorf("ServiceName forms part of the endpoint host and so may not be nil")}
} else if !smithyhttp.ValidateHostLabel(*input.ServiceName) {
	return out, metadata, &smithy.SerializationError{Err: fmt.Errorf("ServiceName forms part of the endpoint host and so must match \"[a-zA-Z0-9-]{1,63}\", but was \"%s\"", *input.ServiceName)}
} else {
	prefix.WriteString(*input.ServiceName)
}
request.HostPrefix = prefix.String()
```

While the need of filling out a template is similar to what is done
with the URL path, the restriction of `hostLabel` to string shapes
that are required means that we don't need such a heavy-weight
solution. Since this solution is minimal, the strategy can easily
be changed if needed.

Additionally, this was inlined into the operation serializer for
the sake of simplicity. You necessarily need access to the operation
input struct, so if this were a middleware then it would need to be
generated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
