### PR TITLE
Add RequestSendError And CanceledError to HTTP ClientHandler

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200917082847-627658712072";
+        private static final String SMITHY_GO = "v0.0.0-20200921234648-239cc835145a";
     }
 }

--- a/errors.go
+++ b/errors.go
@@ -116,3 +116,22 @@ func (e *SerializationError) Error() string {
 
 // Unwrap returns the underlying Error in SerializationError
 func (e *SerializationError) Unwrap() error { return e.Err }
+
+// CanceledError is the error that will be returned by an API request that was
+// canceled. API operations given a Context may return this error when
+// canceled.
+type CanceledError struct {
+	Err error
+}
+
+// CanceledError returns true to satisfy interfaces checking for canceled errors.
+func (*CanceledError) CanceledError() bool { return true }
+
+// Unwrap returns the underlying error, if there was one.
+func (e *CanceledError) Unwrap() error {
+	return e.Err
+}
+
+func (e *CanceledError) Error() string {
+	return fmt.Sprintf("canceled, %v", e.Err)
+}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -63,13 +63,17 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 	return &Response{Response: resp}, metadata, err
 }
 
-// RequestSendError provides a generic request transport error.
+// RequestSendError provides a generic request transport error. This error
+// should wrap errors making HTTP client requests.
+//
+// The ClientHandler will wrap the HTTP client's error if the client request
+// fails, and did not fail because of context canceled.
 type RequestSendError struct {
 	Err error
 }
 
 // ConnectionError return that the error is related to not being able to send
-// the request.
+// the request, or receive a response from the service.
 func (e *RequestSendError) ConnectionError() bool {
 	return true
 }

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 
+	smithy "github.com/awslabs/smithy-go"
 	"github.com/awslabs/smithy-go/middleware"
 )
 
@@ -49,10 +50,37 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 
 	resp, err := c.client.Do(req.Build(ctx))
 	if err != nil {
-		return nil, metadata, err
+		err = &RequestSendError{Err: err}
+
+		// Override the error with a context canceled error, if that was canceled.
+		select {
+		case <-ctx.Done():
+			err = &smithy.CanceledError{Err: ctx.Err()}
+		default:
+		}
 	}
 
-	return &Response{Response: resp}, metadata, nil
+	return &Response{Response: resp}, metadata, err
+}
+
+// RequestSendError provides a generic request transport error.
+type RequestSendError struct {
+	Err error
+}
+
+// ConnectionError return that the error is related to not being able to send
+// the request.
+func (e *RequestSendError) ConnectionError() bool {
+	return true
+}
+
+// Unwrap returns the underlying error, if there was one.
+func (e *RequestSendError) Unwrap() error {
+	return e.Err
+}
+
+func (e *RequestSendError) Error() string {
+	return fmt.Sprintf("request send failed, %v", e.Err)
 }
 
 // WrapLogClient logs the client's HTTP request and response of a round tripped

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	smithy "github.com/awslabs/smithy-go"
+)
+
+func TestClientHandler_Handle(t *testing.T) {
+	cases := map[string]struct {
+		Context   context.Context
+		Client    ClientDo
+		ExpectErr func(error) error
+	}{
+		"no error": {
+			Context: context.Background(),
+			Client: ClientDoFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{}, nil
+			}),
+		},
+		"send error": {
+			Context: context.Background(),
+			Client: ClientDoFunc(func(*http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("some error")
+			}),
+			ExpectErr: func(err error) error {
+				var sendError *RequestSendError
+				if !errors.As(err, &sendError) {
+					return fmt.Errorf("expect error to be %T, %v", sendError, err)
+				}
+
+				var cancelError *smithy.CanceledError
+				if errors.As(err, &cancelError) {
+					return fmt.Errorf("expect error to not be %T, %v", cancelError, err)
+				}
+
+				return nil
+			},
+		},
+		"canceled error": {
+			Context: func() context.Context {
+				ctx, fn := context.WithCancel(context.Background())
+				fn()
+				return ctx
+			}(),
+			Client: ClientDoFunc(func(*http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("some error")
+			}),
+			ExpectErr: func(err error) error {
+				var sendError *RequestSendError
+				if errors.As(err, &sendError) {
+					return fmt.Errorf("expect error to not be %T, %v", sendError, err)
+				}
+
+				var cancelError *smithy.CanceledError
+				if !errors.As(err, &cancelError) {
+					return fmt.Errorf("expect error to be %T, %v", cancelError, err)
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			handler := NewClientHandler(c.Client)
+			resp, _, err := handler.Handle(c.Context, NewStackRequest())
+
+			if c.ExpectErr != nil {
+				if err == nil {
+					t.Fatalf("expect error, got none")
+				}
+				if err = c.ExpectErr(err); err != nil {
+					t.Fatalf("expect error match failed, %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			if _, ok := resp.(*Response); !ok {
+				t.Fatalf("expect Response type, got %T", resp)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Adds wrapping the HTTP client handler's response with an `RequestSendError` for all HTTP request send errors, and `CanceledError` if the context passed in to the handler was canceled and the HTTP client encountered an error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
