### PR TITLE
Fix version numbers in readme

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -7,8 +7,8 @@ Smithy code generators for Go.
 ## Setup
 > Note: These steps assume your current working directory is `smithy-go/codegen` (the directory that contains this README)
 
-1. Install Java 11. If you have multiple versions of Java installed on OSX, use `export JAVA_HOME=`/usr/libexec/java_home -v 11``. **Java 14 is not compatible with Grade 5.x**
-2. Install Go (follow directions for your platform)
+1. Install Java 8. If you have multiple versions of Java installed on OSX, use `export JAVA_HOME=`/usr/libexec/java_home -v 8``. **Java 14 is not compatible with Grade 5.x**
+2. Install Go 1.15 (follow directions for your platform)
 3. Use `./gradlew` to automatically install the correct gradle version. **`brew install gradle` will install Gradle 6.x which is not compatible.**
 4. `./gradlew test` to run the basic tests.
 5. `cd smithy-go-codegen-test; ../gradlew build` to run the codegen tests.


### PR DESCRIPTION
The java version in the readme was wrong, so I fixed it and added a bit about the minimum go version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
