### PR TITLE
Enable custom module import

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -86,14 +86,14 @@ public final class SmithyGoDependency {
     }
 
     private static GoDependency smithy(String relativePath, String alias) {
-        return relativePackage(SMITHY_SOURCE_PATH, relativePath, Versions.SMITHY_GO, alias);
+        return module(SMITHY_SOURCE_PATH, relativePath, Versions.SMITHY_GO, alias);
     }
 
     private static GoDependency goCmp(String relativePath) {
-        return relativePackage(GO_CMP_SOURCE_PATH, relativePath, Versions.GO_CMP, null);
+        return module(GO_CMP_SOURCE_PATH, relativePath, Versions.GO_CMP, null);
     }
 
-    private static GoDependency relativePackage(
+    protected static GoDependency module(
             String moduleImportPath,
             String relativePath,
             String version,

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200924163652-fc0366622e14";
+        private static final String SMITHY_GO = "v0.0.0-20200924212038-173b45457ab8";
     }
 }


### PR DESCRIPTION
Renames method and change access modifier to protected so as to support adding customization modules as go mod dependency.