### PR TITLE
Update Smithy Dependency to v0.1.0

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20200924163652-fc0366622e14";
+        private static final String SMITHY_GO = "v0.1.0";
     }
 }


### PR DESCRIPTION
Update Smithy code generation to use smithy-go at v0.1.0.