### PR TITLE
fix to_ptr address

### DIFF
--- a/ptr/generate.go
+++ b/ptr/generate.go
@@ -152,6 +152,7 @@ var ptrTmpl = template.Must(template.New("ptrTmpl").Parse(`
 	func {{ $.Name }}Slice(vs []{{ $.Symbol }}) []*{{ $.Symbol }} {
 		ps := make([]*{{ $.Symbol }}, len(vs))
 		for i, v := range vs {
+			v := v
 			ps[i] = &v
 		}
 
@@ -163,6 +164,7 @@ var ptrTmpl = template.Must(template.New("ptrTmpl").Parse(`
 	func {{ $.Name }}Map(vs map[string]{{ $.Symbol }}) map[string]*{{ $.Symbol }} {
 		ps := make(map[string]*{{ $.Symbol }}, len(vs))
 		for k, v := range vs {
+			v := v
 			ps[k] = &v
 		}
 

--- a/ptr/generate.go
+++ b/ptr/generate.go
@@ -152,8 +152,8 @@ var ptrTmpl = template.Must(template.New("ptrTmpl").Parse(`
 	func {{ $.Name }}Slice(vs []{{ $.Symbol }}) []*{{ $.Symbol }} {
 		ps := make([]*{{ $.Symbol }}, len(vs))
 		for i, v := range vs {
-			v := v
-			ps[i] = &v
+			vv := v
+			ps[i] = &vv
 		}
 
 		return ps
@@ -164,8 +164,8 @@ var ptrTmpl = template.Must(template.New("ptrTmpl").Parse(`
 	func {{ $.Name }}Map(vs map[string]{{ $.Symbol }}) map[string]*{{ $.Symbol }} {
 		ps := make(map[string]*{{ $.Symbol }}, len(vs))
 		for k, v := range vs {
-			v := v
-			ps[k] = &v
+			vv := v
+			ps[k] = &vv
 		}
 
 		return ps

--- a/ptr/to_ptr.go
+++ b/ptr/to_ptr.go
@@ -15,8 +15,8 @@ func Bool(v bool) *bool {
 func BoolSlice(vs []bool) []*bool {
 	ps := make([]*bool, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -27,8 +27,8 @@ func BoolSlice(vs []bool) []*bool {
 func BoolMap(vs map[string]bool) map[string]*bool {
 	ps := make(map[string]*bool, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -44,8 +44,8 @@ func Byte(v byte) *byte {
 func ByteSlice(vs []byte) []*byte {
 	ps := make([]*byte, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -56,8 +56,8 @@ func ByteSlice(vs []byte) []*byte {
 func ByteMap(vs map[string]byte) map[string]*byte {
 	ps := make(map[string]*byte, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -73,8 +73,8 @@ func String(v string) *string {
 func StringSlice(vs []string) []*string {
 	ps := make([]*string, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -85,8 +85,8 @@ func StringSlice(vs []string) []*string {
 func StringMap(vs map[string]string) map[string]*string {
 	ps := make(map[string]*string, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -102,8 +102,8 @@ func Int(v int) *int {
 func IntSlice(vs []int) []*int {
 	ps := make([]*int, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -114,8 +114,8 @@ func IntSlice(vs []int) []*int {
 func IntMap(vs map[string]int) map[string]*int {
 	ps := make(map[string]*int, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -131,8 +131,8 @@ func Int8(v int8) *int8 {
 func Int8Slice(vs []int8) []*int8 {
 	ps := make([]*int8, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -143,8 +143,8 @@ func Int8Slice(vs []int8) []*int8 {
 func Int8Map(vs map[string]int8) map[string]*int8 {
 	ps := make(map[string]*int8, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -160,8 +160,8 @@ func Int16(v int16) *int16 {
 func Int16Slice(vs []int16) []*int16 {
 	ps := make([]*int16, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -172,8 +172,8 @@ func Int16Slice(vs []int16) []*int16 {
 func Int16Map(vs map[string]int16) map[string]*int16 {
 	ps := make(map[string]*int16, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -189,8 +189,8 @@ func Int32(v int32) *int32 {
 func Int32Slice(vs []int32) []*int32 {
 	ps := make([]*int32, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -201,8 +201,8 @@ func Int32Slice(vs []int32) []*int32 {
 func Int32Map(vs map[string]int32) map[string]*int32 {
 	ps := make(map[string]*int32, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -218,8 +218,8 @@ func Int64(v int64) *int64 {
 func Int64Slice(vs []int64) []*int64 {
 	ps := make([]*int64, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -230,8 +230,8 @@ func Int64Slice(vs []int64) []*int64 {
 func Int64Map(vs map[string]int64) map[string]*int64 {
 	ps := make(map[string]*int64, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -247,8 +247,8 @@ func Uint(v uint) *uint {
 func UintSlice(vs []uint) []*uint {
 	ps := make([]*uint, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -259,8 +259,8 @@ func UintSlice(vs []uint) []*uint {
 func UintMap(vs map[string]uint) map[string]*uint {
 	ps := make(map[string]*uint, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -276,8 +276,8 @@ func Uint8(v uint8) *uint8 {
 func Uint8Slice(vs []uint8) []*uint8 {
 	ps := make([]*uint8, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -288,8 +288,8 @@ func Uint8Slice(vs []uint8) []*uint8 {
 func Uint8Map(vs map[string]uint8) map[string]*uint8 {
 	ps := make(map[string]*uint8, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -305,8 +305,8 @@ func Uint16(v uint16) *uint16 {
 func Uint16Slice(vs []uint16) []*uint16 {
 	ps := make([]*uint16, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -317,8 +317,8 @@ func Uint16Slice(vs []uint16) []*uint16 {
 func Uint16Map(vs map[string]uint16) map[string]*uint16 {
 	ps := make(map[string]*uint16, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -334,8 +334,8 @@ func Uint32(v uint32) *uint32 {
 func Uint32Slice(vs []uint32) []*uint32 {
 	ps := make([]*uint32, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -346,8 +346,8 @@ func Uint32Slice(vs []uint32) []*uint32 {
 func Uint32Map(vs map[string]uint32) map[string]*uint32 {
 	ps := make(map[string]*uint32, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -363,8 +363,8 @@ func Uint64(v uint64) *uint64 {
 func Uint64Slice(vs []uint64) []*uint64 {
 	ps := make([]*uint64, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -375,8 +375,8 @@ func Uint64Slice(vs []uint64) []*uint64 {
 func Uint64Map(vs map[string]uint64) map[string]*uint64 {
 	ps := make(map[string]*uint64, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -392,8 +392,8 @@ func Float32(v float32) *float32 {
 func Float32Slice(vs []float32) []*float32 {
 	ps := make([]*float32, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -404,8 +404,8 @@ func Float32Slice(vs []float32) []*float32 {
 func Float32Map(vs map[string]float32) map[string]*float32 {
 	ps := make(map[string]*float32, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -421,8 +421,8 @@ func Float64(v float64) *float64 {
 func Float64Slice(vs []float64) []*float64 {
 	ps := make([]*float64, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -433,8 +433,8 @@ func Float64Slice(vs []float64) []*float64 {
 func Float64Map(vs map[string]float64) map[string]*float64 {
 	ps := make(map[string]*float64, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps
@@ -450,8 +450,8 @@ func Time(v time.Time) *time.Time {
 func TimeSlice(vs []time.Time) []*time.Time {
 	ps := make([]*time.Time, len(vs))
 	for i, v := range vs {
-		v := v
-		ps[i] = &v
+		vv := v
+		ps[i] = &vv
 	}
 
 	return ps
@@ -462,8 +462,8 @@ func TimeSlice(vs []time.Time) []*time.Time {
 func TimeMap(vs map[string]time.Time) map[string]*time.Time {
 	ps := make(map[string]*time.Time, len(vs))
 	for k, v := range vs {
-		v := v
-		ps[k] = &v
+		vv := v
+		ps[k] = &vv
 	}
 
 	return ps

--- a/ptr/to_ptr.go
+++ b/ptr/to_ptr.go
@@ -15,6 +15,7 @@ func Bool(v bool) *bool {
 func BoolSlice(vs []bool) []*bool {
 	ps := make([]*bool, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -26,6 +27,7 @@ func BoolSlice(vs []bool) []*bool {
 func BoolMap(vs map[string]bool) map[string]*bool {
 	ps := make(map[string]*bool, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -42,6 +44,7 @@ func Byte(v byte) *byte {
 func ByteSlice(vs []byte) []*byte {
 	ps := make([]*byte, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -53,6 +56,7 @@ func ByteSlice(vs []byte) []*byte {
 func ByteMap(vs map[string]byte) map[string]*byte {
 	ps := make(map[string]*byte, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -69,6 +73,7 @@ func String(v string) *string {
 func StringSlice(vs []string) []*string {
 	ps := make([]*string, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -80,6 +85,7 @@ func StringSlice(vs []string) []*string {
 func StringMap(vs map[string]string) map[string]*string {
 	ps := make(map[string]*string, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -96,6 +102,7 @@ func Int(v int) *int {
 func IntSlice(vs []int) []*int {
 	ps := make([]*int, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -107,6 +114,7 @@ func IntSlice(vs []int) []*int {
 func IntMap(vs map[string]int) map[string]*int {
 	ps := make(map[string]*int, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -123,6 +131,7 @@ func Int8(v int8) *int8 {
 func Int8Slice(vs []int8) []*int8 {
 	ps := make([]*int8, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -134,6 +143,7 @@ func Int8Slice(vs []int8) []*int8 {
 func Int8Map(vs map[string]int8) map[string]*int8 {
 	ps := make(map[string]*int8, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -150,6 +160,7 @@ func Int16(v int16) *int16 {
 func Int16Slice(vs []int16) []*int16 {
 	ps := make([]*int16, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -161,6 +172,7 @@ func Int16Slice(vs []int16) []*int16 {
 func Int16Map(vs map[string]int16) map[string]*int16 {
 	ps := make(map[string]*int16, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -177,6 +189,7 @@ func Int32(v int32) *int32 {
 func Int32Slice(vs []int32) []*int32 {
 	ps := make([]*int32, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -188,6 +201,7 @@ func Int32Slice(vs []int32) []*int32 {
 func Int32Map(vs map[string]int32) map[string]*int32 {
 	ps := make(map[string]*int32, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -204,6 +218,7 @@ func Int64(v int64) *int64 {
 func Int64Slice(vs []int64) []*int64 {
 	ps := make([]*int64, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -215,6 +230,7 @@ func Int64Slice(vs []int64) []*int64 {
 func Int64Map(vs map[string]int64) map[string]*int64 {
 	ps := make(map[string]*int64, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -231,6 +247,7 @@ func Uint(v uint) *uint {
 func UintSlice(vs []uint) []*uint {
 	ps := make([]*uint, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -242,6 +259,7 @@ func UintSlice(vs []uint) []*uint {
 func UintMap(vs map[string]uint) map[string]*uint {
 	ps := make(map[string]*uint, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -258,6 +276,7 @@ func Uint8(v uint8) *uint8 {
 func Uint8Slice(vs []uint8) []*uint8 {
 	ps := make([]*uint8, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -269,6 +288,7 @@ func Uint8Slice(vs []uint8) []*uint8 {
 func Uint8Map(vs map[string]uint8) map[string]*uint8 {
 	ps := make(map[string]*uint8, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -285,6 +305,7 @@ func Uint16(v uint16) *uint16 {
 func Uint16Slice(vs []uint16) []*uint16 {
 	ps := make([]*uint16, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -296,6 +317,7 @@ func Uint16Slice(vs []uint16) []*uint16 {
 func Uint16Map(vs map[string]uint16) map[string]*uint16 {
 	ps := make(map[string]*uint16, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -312,6 +334,7 @@ func Uint32(v uint32) *uint32 {
 func Uint32Slice(vs []uint32) []*uint32 {
 	ps := make([]*uint32, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -323,6 +346,7 @@ func Uint32Slice(vs []uint32) []*uint32 {
 func Uint32Map(vs map[string]uint32) map[string]*uint32 {
 	ps := make(map[string]*uint32, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -339,6 +363,7 @@ func Uint64(v uint64) *uint64 {
 func Uint64Slice(vs []uint64) []*uint64 {
 	ps := make([]*uint64, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -350,6 +375,7 @@ func Uint64Slice(vs []uint64) []*uint64 {
 func Uint64Map(vs map[string]uint64) map[string]*uint64 {
 	ps := make(map[string]*uint64, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -366,6 +392,7 @@ func Float32(v float32) *float32 {
 func Float32Slice(vs []float32) []*float32 {
 	ps := make([]*float32, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -377,6 +404,7 @@ func Float32Slice(vs []float32) []*float32 {
 func Float32Map(vs map[string]float32) map[string]*float32 {
 	ps := make(map[string]*float32, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -393,6 +421,7 @@ func Float64(v float64) *float64 {
 func Float64Slice(vs []float64) []*float64 {
 	ps := make([]*float64, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -404,6 +433,7 @@ func Float64Slice(vs []float64) []*float64 {
 func Float64Map(vs map[string]float64) map[string]*float64 {
 	ps := make(map[string]*float64, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 
@@ -420,6 +450,7 @@ func Time(v time.Time) *time.Time {
 func TimeSlice(vs []time.Time) []*time.Time {
 	ps := make([]*time.Time, len(vs))
 	for i, v := range vs {
+		v := v
 		ps[i] = &v
 	}
 
@@ -431,6 +462,7 @@ func TimeSlice(vs []time.Time) []*time.Time {
 func TimeMap(vs map[string]time.Time) map[string]*time.Time {
 	ps := make(map[string]*time.Time, len(vs))
 	for k, v := range vs {
+		v := v
 		ps[k] = &v
 	}
 

--- a/ptr/to_ptr_test.go
+++ b/ptr/to_ptr_test.go
@@ -1,0 +1,690 @@
+package ptr
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBool(t *testing.T) {
+	var v *bool
+	v = Bool(true)
+	if !*v {
+		t.Errorf("expected %t, but received %t", true, *v)
+	}
+	v = Bool(false)
+	if *v {
+		t.Errorf("expected %t, but received %t", false, *v)
+	}
+}
+
+func TestBoolSlice(t *testing.T) {
+	s := []bool{true, false}
+	ps := BoolSlice(s)
+	if len(ps) != 2 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if !*ps[0] {
+		t.Errorf("expected %t, but received %t", true, *ps[0])
+	}
+	if *ps[1] {
+		t.Errorf("expected %t, but received %t", false, *ps[1])
+	}
+}
+
+func TestBoolMap(t *testing.T) {
+	s := map[string]bool{
+		"true":  true,
+		"false": false,
+	}
+	ps := BoolMap(s)
+	if len(ps) != 2 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if !*ps["true"] {
+		t.Errorf("expected %t, but received %t", true, *ps["true"])
+	}
+	if *ps["false"] {
+		t.Errorf("expected %t, but received %t", false, *ps["false"])
+	}
+}
+
+func TestByte(t *testing.T) {
+	v := Byte(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestByteSlice(t *testing.T) {
+	s := []byte{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := ByteSlice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestByteMap(t *testing.T) {
+	s := map[string]byte{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := ByteMap(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestString(t *testing.T) {
+	v := String("foo")
+	if *v != "foo" {
+		t.Errorf("expected %q, but received %q", "foo", *v)
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	s := []string{"foo", "bar", "fizz", "buzz", "hoge", "fuga"}
+	ps := StringSlice(s)
+	if len(ps) != 6 {
+		t.Errorf("expected %d, but received %d", 6, len(ps))
+	}
+	if *ps[0] != "foo" {
+		t.Errorf("expected %q, but received %q", "foo", *ps[0])
+	}
+	if *ps[5] != "fuga" {
+		t.Errorf("expected %q, but received %q", "fuga", *ps[5])
+	}
+}
+
+func TestStringMap(t *testing.T) {
+	s := map[string]string{
+		"foo":  "bar",
+		"fizz": "buzz",
+		"hoge": "fuga",
+	}
+	ps := StringMap(s)
+	if len(ps) != 3 {
+		t.Errorf("expected %d, but received %d", 3, len(ps))
+	}
+	if *ps["foo"] != "bar" {
+		t.Errorf("expected %q, but received %q", "foo", *ps["foo"])
+	}
+	if *ps["hoge"] != "fuga" {
+		t.Errorf("expected %q, but received %q", "fuga", *ps["hoge"])
+	}
+}
+
+func TestInt(t *testing.T) {
+	v := Int(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestIntSlice(t *testing.T) {
+	s := []int{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := IntSlice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestIntMap(t *testing.T) {
+	s := map[string]int{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := IntMap(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestInt8(t *testing.T) {
+	v := Int8(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestInt8Slice(t *testing.T) {
+	s := []int8{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Int8Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestInt8Map(t *testing.T) {
+	s := map[string]int8{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Int8Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestInt16(t *testing.T) {
+	v := Int16(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestIntSlice16(t *testing.T) {
+	s := []int16{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Int16Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestInt16Map(t *testing.T) {
+	s := map[string]int16{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Int16Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestInt32(t *testing.T) {
+	v := Int32(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestInt32Slice(t *testing.T) {
+	s := []int32{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Int32Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestInt32Map(t *testing.T) {
+	s := map[string]int32{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Int32Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestInt64(t *testing.T) {
+	v := Int64(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestInt64Slice(t *testing.T) {
+	s := []int64{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Int64Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestInt64Map(t *testing.T) {
+	s := map[string]int64{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Int64Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestUint(t *testing.T) {
+	v := Uint(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestUintSlice(t *testing.T) {
+	s := []uint{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := UintSlice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestUintMap(t *testing.T) {
+	s := map[string]uint{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := UintMap(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestUint8(t *testing.T) {
+	v := Uint8(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestUint8Slice(t *testing.T) {
+	s := []uint8{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Uint8Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestUint8Map(t *testing.T) {
+	s := map[string]uint8{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Uint8Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestUint16(t *testing.T) {
+	v := Uint16(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestUintSlice16(t *testing.T) {
+	s := []uint16{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Uint16Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestUint16Map(t *testing.T) {
+	s := map[string]uint{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := UintMap(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestUint32(t *testing.T) {
+	v := Uint32(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestUint32Slice(t *testing.T) {
+	s := []uint32{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Uint32Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestUint32Map(t *testing.T) {
+	s := map[string]uint32{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Uint32Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestUint64(t *testing.T) {
+	v := Uint64(42)
+	if *v != 42 {
+		t.Errorf("expected %d, but received %d", 42, *v)
+	}
+}
+
+func TestUint64Slice(t *testing.T) {
+	s := []uint64{1, 1, 2, 3, 5, 8, 13, 21}
+	ps := Uint64Slice(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 8, len(ps))
+	}
+	if *ps[0] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps[0])
+	}
+	if *ps[7] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps[7])
+	}
+}
+
+func TestUint64Map(t *testing.T) {
+	s := map[string]uint64{
+		"F0": 1,
+		"F1": 1,
+		"F2": 2,
+		"F3": 3,
+		"F4": 5,
+		"F5": 8,
+		"F6": 13,
+		"F7": 21,
+	}
+	ps := Uint64Map(s)
+	if len(ps) != 8 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if *ps["F0"] != 1 {
+		t.Errorf("expected %d, but received %d", 1, *ps["F0"])
+	}
+	if *ps["F7"] != 21 {
+		t.Errorf("expected %d, but received %d", 21, *ps["F7"])
+	}
+}
+
+func TestFloat32(t *testing.T) {
+	v := Float32(0.5)
+	if *v != 0.5 {
+		t.Errorf("expected %f, but received %f", 0.5, *v)
+	}
+}
+
+func TestFloat32Slice(t *testing.T) {
+	s := []float32{0.5, 0.25, 0.125, 0.0625}
+	ps := Float32Slice(s)
+	if len(ps) != 4 {
+		t.Errorf("expected %d, but received %d", 4, len(ps))
+	}
+	if *ps[0] != 0.5 {
+		t.Errorf("expected %f, but received %f", 0.5, *ps[0])
+	}
+	if *ps[3] != 0.0625 {
+		t.Errorf("expected %f, but received %f", 0.0625, *ps[7])
+	}
+}
+
+func TestFloat32Map(t *testing.T) {
+	s := map[string]float32{
+		"F0": 0.5,
+		"F1": 0.25,
+		"F2": 0.125,
+		"F3": 0.0625,
+	}
+	ps := Float32Map(s)
+	if len(ps) != 4 {
+		t.Errorf("expected %d, but received %d", 4, len(ps))
+	}
+	if *ps["F0"] != 0.5 {
+		t.Errorf("expected %f, but received %f", 0.5, *ps["F0"])
+	}
+	if *ps["F3"] != 0.0625 {
+		t.Errorf("expected %f, but received %f", 0.0625, *ps["F3"])
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	v := Float64(0.5)
+	if *v != 0.5 {
+		t.Errorf("expected %f, but received %f", 0.5, *v)
+	}
+}
+
+func TestFloat64Slice(t *testing.T) {
+	s := []float64{0.5, 0.25, 0.125, 0.0625}
+	ps := Float64Slice(s)
+	if len(ps) != 4 {
+		t.Errorf("expected %d, but received %d", 4, len(ps))
+	}
+	if *ps[0] != 0.5 {
+		t.Errorf("expected %f, but received %f", 0.5, *ps[0])
+	}
+	if *ps[3] != 0.0625 {
+		t.Errorf("expected %f, but received %f", 0.0625, *ps[7])
+	}
+}
+
+func TestFloat64Map(t *testing.T) {
+	s := map[string]float64{
+		"F0": 0.5,
+		"F1": 0.25,
+		"F2": 0.125,
+		"F3": 0.0625,
+	}
+	ps := Float64Map(s)
+	if len(ps) != 4 {
+		t.Errorf("expected %d, but received %d", 4, len(ps))
+	}
+	if *ps["F0"] != 0.5 {
+		t.Errorf("expected %f, but received %f", 0.5, *ps["F0"])
+	}
+	if *ps["F3"] != 0.0625 {
+		t.Errorf("expected %f, but received %f", 0.0625, *ps["F3"])
+	}
+}
+
+func TestTime(t *testing.T) {
+	v := Time(time.Unix(1234567890, 0))
+	if v.Unix() != 1234567890 {
+		t.Errorf("expected %d, but received %d", 1234567890, v.Unix())
+	}
+}
+
+func TestTimeSlice(t *testing.T) {
+	s := []time.Time{time.Unix(1234567890, 0), time.Unix(2147483647, 0)}
+	ps := TimeSlice(s)
+	if len(ps) != 2 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if ps[0].Unix() != 1234567890 {
+		t.Errorf("expected %d, but received %d", 1234567890, ps[0].Unix())
+	}
+	if ps[1].Unix() != 2147483647 {
+		t.Errorf("expected %d, but received %d", 2147483647, ps[1].Unix())
+	}
+}
+
+func TestTimeMap(t *testing.T) {
+	s := map[string]time.Time{
+		"2009-02-13T23:31:30Z": time.Unix(1234567890, 0),
+		"2038-01-19T03:14:07Z": time.Unix(2147483647, 0),
+	}
+	ps := TimeMap(s)
+	if len(ps) != 2 {
+		t.Errorf("expected %d, but received %d", 2, len(ps))
+	}
+	if ps["2009-02-13T23:31:30Z"].Unix() != 1234567890 {
+		t.Errorf("expected %d, but received %d", 1234567890, ps["2009-02-13T23:31:30Z"].Unix())
+	}
+	if ps["2038-01-19T03:14:07Z"].Unix() != 2147483647 {
+		t.Errorf("expected %d, but received %d", 2147483647, ps["2038-01-19T03:14:07Z"].Unix())
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

related to https://github.com/aws/aws-sdk-go-v2/issues/777
back port of https://github.com/aws/aws-sdk-go-v2/pull/778

all members of the slice point same address.

https://play.golang.org/p/FUBdYewJvLH

```go
package main

import (
	"fmt"
)

func StringSlice(vs []string) []*string {
	ps := make([]*string, len(vs))
	for i, v := range vs {
		ps[i] = &v
	}

	return ps
}

func main() {
	r := StringSlice([]string{"abc", "def"})

	fmt.Printf("%p\n", r[0])
	fmt.Printf("%p\n", r[1])
	//Output:
	//0xc0000961f0
	//0xc0000961f0
}
```

*Description of changes:*

```go
	for i, v := range vs {
		v := v // NEEDS THIS LINE
		ps[i] = &v
	}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
