### PR TITLE
ptr: Expose pointer types for codegen

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.1.0";
+        private static final String SMITHY_GO = "v0.0.0-20200930175536-2cd7f70a8c2f";
     }
 }

--- a/ptr/doc.go
+++ b/ptr/doc.go
@@ -1,5 +1,5 @@
 // Package ptr provides utilities for converting scalar literal type values to and from pointers inline.
 package ptr
 
-//go:generate go run generate.go
+//go:generate go run -tags codegen generate.go
 //go:generate gofmt -w -s .

--- a/ptr/gen_scalars.go
+++ b/ptr/gen_scalars.go
@@ -1,0 +1,81 @@
+// +build codegen
+
+package ptr
+
+import "strings"
+
+func GetScalars() Scalars {
+	return Scalars{
+		{Type: "bool"},
+		{Type: "byte"},
+		{Type: "string"},
+		{Type: "int"},
+		{Type: "int8"},
+		{Type: "int16"},
+		{Type: "int32"},
+		{Type: "int64"},
+		{Type: "uint"},
+		{Type: "uint8"},
+		{Type: "uint16"},
+		{Type: "uint32"},
+		{Type: "uint64"},
+		{Type: "float32"},
+		{Type: "float64"},
+		{Type: "Time", Import: &Import{Path: "time"}},
+	}
+}
+
+// Import provides the import path and optional alias
+type Import struct {
+	Path  string
+	Alias string
+}
+
+// Package returns the Go package name for the import. Returns alias if set.
+func (i Import) Package() string {
+	if v := i.Alias; len(v) != 0 {
+		return v
+	}
+
+	if v := i.Path; len(v) != 0 {
+		parts := strings.Split(v, "/")
+		pkg := parts[len(parts)-1]
+		return pkg
+	}
+
+	return ""
+}
+
+// Scalar provides the definition of a type to generate pointer utilities for.
+type Scalar struct {
+	Type   string
+	Import *Import
+}
+
+// Name returns the exported function name for the type.
+func (t Scalar) Name() string {
+	return strings.Title(t.Type)
+}
+
+// Symbol returns the scalar's Go symbol with path if needed.
+func (t Scalar) Symbol() string {
+	if t.Import != nil {
+		return t.Import.Package() + "." + t.Type
+	}
+	return t.Type
+}
+
+// Scalars is a list of scalars.
+type Scalars []Scalar
+
+// Imports returns all imports for the scalars.
+func (ts Scalars) Imports() []*Import {
+	imports := []*Import{}
+	for _, t := range ts {
+		if v := t.Import; v != nil {
+			imports = append(imports, v)
+		}
+	}
+
+	return imports
+}

--- a/ptr/generate.go
+++ b/ptr/generate.go
@@ -6,84 +6,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"text/template"
+
+	"github.com/awslabs/smithy-go/ptr"
 )
 
-// Import provides the import path and optional alias
-type Import struct {
-	Path  string
-	Alias string
-}
-
-// Package returns the Go package name for the import. Returns alias if set.
-func (i Import) Package() string {
-	if v := i.Alias; len(v) != 0 {
-		return v
-	}
-
-	if v := i.Path; len(v) != 0 {
-		parts := strings.Split(v, "/")
-		pkg := parts[len(parts)-1]
-		return pkg
-	}
-
-	return ""
-}
-
-// Scalar provides the definition of a type to generate pointer utilities for.
-type Scalar struct {
-	Type   string
-	Import *Import
-}
-
-// Name returns the exported function name for the type.
-func (t Scalar) Name() string {
-	return strings.Title(t.Type)
-}
-
-// Symbol returns the scalar's Go symbol with path if needed.
-func (t Scalar) Symbol() string {
-	if t.Import != nil {
-		return t.Import.Package() + "." + t.Type
-	}
-	return t.Type
-}
-
-// Scalars is a list of scalars.
-type Scalars []Scalar
-
-// Imports returns all imports for the scalars.
-func (ts Scalars) Imports() []*Import {
-	imports := []*Import{}
-	for _, t := range ts {
-		if v := t.Import; v != nil {
-			imports = append(imports, v)
-		}
-	}
-
-	return imports
-}
-
 func main() {
-	types := Scalars{
-		{Type: "bool"},
-		{Type: "byte"},
-		{Type: "string"},
-		{Type: "int"},
-		{Type: "int8"},
-		{Type: "int16"},
-		{Type: "int32"},
-		{Type: "int64"},
-		{Type: "uint"},
-		{Type: "uint8"},
-		{Type: "uint16"},
-		{Type: "uint32"},
-		{Type: "uint64"},
-		{Type: "float32"},
-		{Type: "float64"},
-		{Type: "Time", Import: &Import{Path: "time"}},
-	}
+	types := ptr.GetScalars()
 
 	for filename, tmplName := range map[string]string{
 		"to_ptr.go":   "scalar to pointer",
@@ -95,7 +24,7 @@ func main() {
 	}
 }
 
-func generateFile(filename string, tmplName string, types Scalars) error {
+func generateFile(filename string, tmplName string, types ptr.Scalars) error {
 	f, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("failed to create %s file, %v", filename, err)


### PR DESCRIPTION
Adds exporting the pointer types when the `codegen` build flag is present for the `ptr` package. This allows the v2 SDK to generate wrappers around these shared definition of the types generated.

Related to https://github.com/aws/aws-sdk-go-v2/pull/778, https://github.com/aws/aws-sdk-go-v2/pull/781, and https://github.com/awslabs/smithy-go/pull/191

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
