### PR TITLE
Add documenation of requirement members.

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -33,6 +33,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.StringTrait;
 import software.amazon.smithy.utils.CodeWriter;
 import software.amazon.smithy.utils.StringUtils;
@@ -261,6 +262,14 @@ public final class GoWriter extends CodeWriter {
                             .map(StringTrait::getValue)
                             .ifPresent(mediaType -> writeDocs(
                                     "\n\nThis value conforms to the media type: " + mediaType));
+
+                    member.getMemberTrait(model, RequiredTrait.class)
+                            .ifPresent((value) -> {
+                                if (docs.length() != 0) {
+                                    writeDocs("");
+                                }
+                                writeDocs("This member is required.");
+                            });
                     return true;
                 }).orElse(false);
     }


### PR DESCRIPTION
Adds documentation to state the member is required in the generated structures.

```go
 type CreateGroupInput struct {
        // The case-sensitive name of the new group. Default is a reserved name and names
        // must be unique.
+       //
+       // This member is required.
        GroupName *string
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
