### PR TITLE
codegen: Add whitespace between struct members

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -89,6 +89,8 @@ final class StructureGenerator implements Runnable {
         writer.writeShapeDocs(shape);
         writer.openBlock("type $L struct {", symbol.getName());
         for (MemberShape member : shape.getAllMembers().values()) {
+            writer.write("");
+
             String memberName = symbolProvider.toMemberName(member);
             writer.writeMemberDocs(model, member);
 
@@ -96,6 +98,7 @@ final class StructureGenerator implements Runnable {
             if (isInputStructure) {
                 memberSymbol = memberSymbol.getProperty(SymbolUtils.INPUT_VARIANT, Symbol.class).orElse(memberSymbol);
             }
+
             writer.write("$L $P", memberName, memberSymbol);
         }
         runnable.run();


### PR DESCRIPTION
Updates the struct member code generation to add whitespace between members to improve their readability.

```go
 // Creates an archive rule.
 type CreateArchiveRuleInput struct {
+
        // The name of the created analyzer.
        AnalyzerName *string
+
        // The name of the rule to create.
        RuleName *string
+
        // The criteria for the rule.
        Filter map[string]*types.Criterion
+
        // A client token.
        ClientToken *string
 }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
