### PR TITLE
codegen: Sort struct members by required and alphabetic order

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -89,7 +89,7 @@ final class StructureGenerator implements Runnable {
         writer.writeShapeDocs(shape);
         writer.openBlock("type $L struct {", symbol.getName());
 
-        CodegenUtils.SortedMembers sortedMembers = new CodegenUtils.SortedMembers(model, symbolProvider);
+        CodegenUtils.SortedMembers sortedMembers = new CodegenUtils.SortedMembers(symbolProvider);
         shape.getAllMembers().values().stream().sorted(sortedMembers).forEach((member) -> {
             writer.write("");
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -88,7 +88,9 @@ final class StructureGenerator implements Runnable {
     public void renderStructure(Runnable runnable, boolean isInputStructure) {
         writer.writeShapeDocs(shape);
         writer.openBlock("type $L struct {", symbol.getName());
-        for (MemberShape member : shape.getAllMembers().values()) {
+
+        CodegenUtils.SortedMembers sortedMembers = new CodegenUtils.SortedMembers(model, symbolProvider);
+        shape.getAllMembers().values().stream().sorted(sortedMembers).forEach((member) -> {
             writer.write("");
 
             String memberName = symbolProvider.toMemberName(member);
@@ -100,7 +102,8 @@ final class StructureGenerator implements Runnable {
             }
 
             writer.write("$L $P", memberName, memberSymbol);
-        }
+        });
+
         runnable.run();
         writer.closeBlock("}").write("");
     }


### PR DESCRIPTION
Updates the struct codegen to sort struct members by required first and alphabetic next. This updates the struct codegen to list required members before optional members in an API.

```diff
 type CreateAnalyzerInput struct {

        // The name of the analyzer to create.
        //
        // This member is required.
        AnalyzerName *string

        // The type of analyzer to create. Only ACCOUNT analyzers are supported. You can
        // create only one analyzer per account per Region.
       //
       // This member is required.
        Type types.Type

        // Specifies the archive rules to add for the analyzer. Archive rules automatically
        // archive findings that meet the criteria you define for the rule.
        ArchiveRules []*types.InlineArchiveRule

-       // The tags to apply to the analyzer.
-       Tags map[string]*string

        // A client token.
        ClientToken *string

+       // The tags to apply to the analyzer.
+       Tags map[string]*string
 }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
