### PR TITLE
Update minimum smithy versions

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -19,7 +19,7 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen.test"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.1")
+    id("software.amazon.smithy").version("0.5.2")
 }
 
 repositories {
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.1.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.2.0,2.0.0[")
     implementation(project(":smithy-go-codegen"))
 }
 

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -18,8 +18,8 @@ extra["displayName"] = "Smithy :: Go :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.1.0,2.0.0[")
+    api("software.amazon.smithy:smithy-codegen-core:[1.2.0,2.0.0[")
     api("com.atlassian.commonmark:commonmark:0.14.0")
     api("org.jsoup:jsoup:1.13.1")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.1.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.2.0,2.0.0[")
 }


### PR DESCRIPTION
This updates the minimum smithy versions to the latest minor versions. We need to bump this for the http status code binding, but also this release fixes a number of bugs that would prevent building on Windows.
