### PR TITLE
codegen: Add support for codegen adding unexported members to api structure shape

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.codegen.core.ReservedWords;
 import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.trait.UnexportedMemberTrait;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
@@ -222,7 +223,11 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private String getDefaultMemberName(MemberShape shape) {
-        return StringUtils.capitalize(removeLeadingUnderscores(shape.getMemberName()));
+        String memberName =  StringUtils.capitalize(removeLeadingUnderscores(shape.getMemberName()));
+        if (shape.hasTrait(UnexportedMemberTrait.class)) {
+            memberName = Character.toLowerCase(memberName.charAt(0)) + memberName.substring(1);
+        }
+        return memberName;
     }
 
     private String removeLeadingUnderscores(String value) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/trait/UnexportedMemberTrait.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/trait/UnexportedMemberTrait.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ *
+ */
+
+package software.amazon.smithy.go.codegen.trait;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+
+/**
+ * Provides a trait to decorate an member as unexported, so it will not be exported within the containing structure.
+ * This should only be used on top level input/output structure shapes, because internal members of non-input/output
+ * shapes are not visible outside of the API client's "types" package.
+ */
+public class UnexportedMemberTrait extends AnnotationTrait {
+    public static final ShapeId ID = ShapeId.from("smithy.go.trait#UnexportedMember");
+
+    public UnexportedMemberTrait() {
+        this(Node.objectNode());
+    }
+
+    public UnexportedMemberTrait(ObjectNode node) {
+        super(ID, node);
+    }
+
+    public static final class Provider extends AnnotationTrait.Provider<UnexportedMemberTrait> {
+        public Provider() {
+            super(ID, UnexportedMemberTrait::new);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for generating unexported members into an API model's structure shapes. This allows unexported members to be injected into the structure shapes.

Adds utility to expect a member by name or predicate in a structure shape.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
