### PR TITLE
add support for checksum required trait

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20201009221937-21015eb9ec4b";
+        private static final String SMITHY_GO = "v0.0.0-20201012164308-5e070c242e0f";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/AddChecksumRequiredMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/AddChecksumRequiredMiddleware.java
@@ -24,8 +24,10 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
 import software.amazon.smithy.utils.ListUtils;
 
-public class ChecksumRequiredMiddlewareGenerator implements GoIntegration {
-
+/**
+ * Adds middleware supporting httpChecksumRequired trait behavior.
+ */
+public class AddChecksumRequiredMiddleware implements GoIntegration {
     @Override
     public byte getOrder() {
         return 127;
@@ -45,6 +47,7 @@ public class ChecksumRequiredMiddlewareGenerator implements GoIntegration {
        );
     }
 
+    // return true if operation shape is decorated with `httpChecksumRequired` trait.
     private boolean hasChecksumRequiredTrait(Model model, ServiceShape service, OperationShape operation) {
         return operation.hasTrait(HttpChecksumRequiredTrait.class);
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ChecksumRequiredMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ChecksumRequiredMiddlewareGenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.List;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
+import software.amazon.smithy.utils.ListUtils;
+
+public class ChecksumRequiredMiddlewareGenerator implements GoIntegration {
+
+    @Override
+    public byte getOrder() {
+        return 127;
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+       return ListUtils.of(
+              RuntimeClientPlugin.builder()
+                      .operationPredicate(this::hasChecksumRequiredTrait)
+                      .registerMiddleware(MiddlewareRegistrar.builder()
+                              .resolvedFunction(SymbolUtils.createValueSymbolBuilder(
+                                      "AddChecksumMiddleware",
+                                      SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build())
+                              .build())
+                      .build()
+       );
+    }
+
+    private boolean hasChecksumRequiredTrait(Model model, ServiceShape service, OperationShape operation) {
+        return operation.hasTrait(HttpChecksumRequiredTrait.class);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -1,2 +1,3 @@
 software.amazon.smithy.go.codegen.integration.ValidationGenerator
 software.amazon.smithy.go.codegen.integration.IdempotencyTokenMiddlewareGenerator
+software.amazon.smithy.go.codegen.integration.ChecksumRequiredMiddlewareGenerator

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -1,3 +1,3 @@
 software.amazon.smithy.go.codegen.integration.ValidationGenerator
 software.amazon.smithy.go.codegen.integration.IdempotencyTokenMiddlewareGenerator
-software.amazon.smithy.go.codegen.integration.ChecksumRequiredMiddlewareGenerator
+software.amazon.smithy.go.codegen.integration.AddChecksumRequiredMiddleware

--- a/transport/http/checksum_middleware.go
+++ b/transport/http/checksum_middleware.go
@@ -9,24 +9,24 @@ import (
 
 const contentMD5Header = "Content-Md5"
 
-// ChecksumMiddleware provides a middleware to compute and set
-// required checksum for a http request
-type checksumMiddleware struct {
+// contentMD5ChecksumMiddleware provides a middleware to compute and set
+// content-md5 checksum for a http request
+type contentMD5ChecksumMiddleware struct {
 }
 
 // AddChecksumMiddleware adds checksum middleware to middleware's
 // build step.
 func AddChecksumMiddleware(stack *middleware.Stack) {
 	// This middleware must be executed before request body is set.
-	stack.Build.Add(&checksumMiddleware{}, middleware.Before)
+	stack.Build.Add(&contentMD5ChecksumMiddleware{}, middleware.Before)
 }
 
 // ID the identifier for the checksum middleware
-func (m *checksumMiddleware) ID() string { return "ChecksumRequiredMiddleware" }
+func (m *contentMD5ChecksumMiddleware) ID() string { return "ChecksumRequiredMiddleware" }
 
 // HandleBuild adds behavior to compute md5 checksum and add content-md5 header
 // on http request
-func (m *checksumMiddleware) HandleBuild(
+func (m *contentMD5ChecksumMiddleware) HandleBuild(
 	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
 ) (
 	out middleware.BuildOutput, metadata middleware.Metadata, err error,
@@ -48,11 +48,11 @@ func (m *checksumMiddleware) HandleBuild(
 			return out, metadata, fmt.Errorf("error computing md5 checksum, %w", err)
 		}
 
-		// reset the request body
+		// reset the request stream
 		req.RewindStream()
 
 		// set the 'Content-MD5' header
-		req.Header.Set("Content-MD5", string(v))
+		req.Header.Set(contentMD5Header, string(v))
 	}
 
 	// set md5 header value

--- a/transport/http/checksum_middleware.go
+++ b/transport/http/checksum_middleware.go
@@ -1,0 +1,62 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/awslabs/smithy-go/middleware"
+)
+
+const contentMD5Header = "Content-Md5"
+
+// ChecksumMiddleware provides a middleware to compute and set
+// required checksum for a http request
+type checksumMiddleware struct {
+}
+
+// AddChecksumMiddleware adds checksum middleware to middleware's
+// build step.
+func AddChecksumMiddleware(stack *middleware.Stack) {
+	stack.Build.Add(&checksumMiddleware{}, middleware.After)
+}
+
+// ID the identifier for the checksum middleware
+func (m *checksumMiddleware) ID() string { return "ChecksumRequiredMiddleware" }
+
+// HandleBuild adds behavior to compute md5 checksum and add content-md5 header
+// on http request
+func (m *checksumMiddleware) HandleBuild(
+	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
+) (
+	out middleware.BuildOutput, metadata middleware.Metadata, err error,
+) {
+	req, ok := in.Request.(*Request)
+	if !ok {
+		return out, metadata, fmt.Errorf("unknown request type %T", req)
+	}
+
+	// if Content-MD5 header is already present, return
+	if v := req.Header.Get(contentMD5Header); len(v) != 0 {
+		return next.HandleBuild(ctx, in)
+	}
+
+	readBuff := make([]byte, 0)
+	readBody := bytes.NewBuffer(readBuff)
+	body := io.TeeReader(req.Body, readBody)
+
+	// compute md5 checksum
+	v, err := computeMD5Checksum(body)
+	if err != nil {
+		return out, metadata, fmt.Errorf("error computing md5 checksum, %w", err)
+	}
+
+	// reset the request body
+	req.Body = ioutil.NopCloser(readBody)
+
+	// set md5 header value
+	req.Header.Set("Content-MD5", string(v))
+	return next.HandleBuild(ctx, in)
+}

--- a/transport/http/checksum_middleware.go
+++ b/transport/http/checksum_middleware.go
@@ -53,7 +53,7 @@ func (m *contentMD5ChecksumMiddleware) HandleBuild(
 		// reset the request stream
 		if err := req.RewindStream(); err != nil {
 			return out, metadata, fmt.Errorf(
-				"error rewinding request stream after computing md5 checksum")
+				"error rewinding request stream after computing md5 checksum, %w", err)
 		}
 
 		// set the 'Content-MD5' header

--- a/transport/http/checksum_middleware_test.go
+++ b/transport/http/checksum_middleware_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestChecksumMiddleware(t *testing.T) {
 	cases := map[string]struct {
-		payload               io.ReadSeeker
+		payload               io.Reader
 		expectedPayloadLength int64
 		expectedMD5Checksum   string
 		expectError           string
@@ -33,6 +33,10 @@ func TestChecksumMiddleware(t *testing.T) {
 			expectedMD5Checksum:   "kAFQmDzST7DWlj99KOF/cg==",
 		},
 		"nil body": {},
+		"unseekable payload": {
+			payload:     bytes.NewBuffer([]byte(`xyz`)),
+			expectError: "error rewinding request stream",
+		},
 	}
 
 	for name, c := range cases {

--- a/transport/http/checksum_middleware_test.go
+++ b/transport/http/checksum_middleware_test.go
@@ -1,0 +1,57 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/smithy-go/middleware"
+)
+
+func TestChecksumMiddleware(t *testing.T) {
+	cases := map[string]struct {
+		requestBody         io.ReadCloser
+		expectedMD5Checksum string
+		expectError         string
+	}{
+		"empty body": {
+			requestBody:         ioutil.NopCloser(bytes.NewBuffer([]byte(``))),
+			expectedMD5Checksum: "1B2M2Y8AsgTpgAmY7PhCfg==",
+		},
+		"standard case": {
+			requestBody:         ioutil.NopCloser(bytes.NewBuffer([]byte(`abc`))),
+			expectedMD5Checksum: "kAFQmDzST7DWlj99KOF/cg==",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			req := NewStackRequest().(*Request)
+			req.Body = c.requestBody
+			m := checksumMiddleware{}
+			_, _, err = m.HandleBuild(context.Background(),
+				middleware.BuildInput{Request: req},
+				nopBuildHandler,
+			)
+
+			if len(c.expectError) != 0 {
+				if err == nil {
+					t.Fatalf("expect error, got none")
+				}
+				if e, a := c.expectError, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect error to contain %q, got %v", e, a)
+				}
+			} else if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			if e, a := c.expectedMD5Checksum, req.Header.Get(contentMD5Header); e != a {
+				t.Errorf("expect md5 checksum : %v, got %v", e, a)
+			}
+		})
+	}
+}

--- a/transport/http/md5_checksum.go
+++ b/transport/http/md5_checksum.go
@@ -11,9 +11,7 @@ import (
 // Returns the byte slice of md5 checksum and an error.
 func computeMD5Checksum(r io.Reader) ([]byte, error) {
 	h := md5.New()
-	// hash the body. seek back to the first position after reading to reset
-	// the body for transmission.  copy errors may be assumed to be from the
-	// body.
+	// copy errors may be assumed to be from the body.
 	_, err := io.Copy(h, r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)

--- a/transport/http/md5_checksum.go
+++ b/transport/http/md5_checksum.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// computeMD5Checksum computes base64 md5 checksum of an io.Reader contents.
+// Returns the byte slice of md5 checksum and an error.
+func computeMD5Checksum(r io.Reader) ([]byte, error) {
+	h := md5.New()
+	// hash the body. seek back to the first position after reading to reset
+	// the body for transmission.  copy errors may be assumed to be from the
+	// body.
+	_, err := io.Copy(h, r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body: %w", err)
+	}
+
+	// encode the md5 checksum in base64.
+	sum := h.Sum(nil)
+	sum64 := make([]byte, base64.StdEncoding.EncodedLen(len(sum)))
+	base64.StdEncoding.Encode(sum64, sum)
+	return sum64, nil
+}


### PR DESCRIPTION

* Adds an integration to use `httpChecksumRequiredTrait` for operations that require Content-MD5 header. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
