### PR TITLE
codegen: Add option to build select API models, instead of all

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenPlugin.java
@@ -31,12 +31,19 @@ public final class GoCodegenPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
+        String onlyBuild = System.getenv("SMITHY_GO_BUILD_API");
+        if (onlyBuild != null && !GoSettings.from(context.getSettings())
+                .getService().toString().startsWith(onlyBuild)) {
+            return;
+        }
+
         new CodegenVisitor(context).execute();
     }
 
     /**
      * Creates a Go symbol provider.
-     * @param model The model to generate symbols for.
+     *
+     * @param model          The model to generate symbols for.
      * @param rootModuleName The name of the package root.
      * @return Returns the created provider.
      */


### PR DESCRIPTION
Adds support for a new environment variable `SMITHY_GO_BUILD_API` that allows you to specify a comma(`,`) deliminated set of `serviceId`s of API model that should be built.

The projections for the models will still be invoked since that is done in smithy core, but the smithy-go build of the model will be skipped for all service Ids not in the list.

Example using aws-sdk-go-v2 to build a single API client.

```sh
SMITHY_GO_BUILD_API="com.amazonaws.rds#AmazonRDSv19,com.amazonaws.ec2#AmazonEC2" make smithy-build gen-repo-mod-replace
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
