### PR TITLE
update smithy go dependency constant to be pseudo hash

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.0.0-20201012164308-5e070c242e0f";
+        private static final String SMITHY_GO = "v0.1.2-0.20201012175301-b4d8737f29d1";
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
* `make generate` on aws sdk go v2 supports go pseudo hashes.

*Description of changes:*
* Updates smithy go dependency used by aws sdk for go v2 sdk to use pseudo go hash


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
