### PR TITLE
Fix doc formatting

### DIFF
--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -19,7 +19,7 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:[1.2.0,2.0.0[")
-    api("com.atlassian.commonmark:commonmark:0.14.0")
+    compile("com.atlassian.commonmark:commonmark:0.15.2")
     api("org.jsoup:jsoup:1.13.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.2.0,2.0.0[")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
@@ -228,9 +228,12 @@ public final class DocumentationConverter {
                 writeNewline();
                 writeNewline();
             } else if (name.equals("a")) {
-                // godoc can't render links with text bodies, so we simply append the link.
-                // Full links do get rendered.
-                writer.writeInline(" ($L)", node.absUrl("href"));
+                String url = node.absUrl("href");
+                if (!url.isEmpty()) {
+                    // godoc can't render links with text bodies, so we simply append the link.
+                    // Full links do get rendered.
+                    writer.writeInline(" ($L)", url);
+                }
             } else if (name.equals("li")) {
                 // Clear out the expectation of a list element if the element's body is empty.
                 needsListPrefix = false;

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
@@ -113,7 +113,8 @@ public class DocumentationConverterTest {
                 Arguments.of("Inline `code`", "Inline code"),
                 Arguments.of("```\ncode block\n```", "    code block"),
                 Arguments.of("```java\ncode block\n```", "    code block"),
-                Arguments.of("foo<br/>bar", "foo\n\nbar")
+                Arguments.of("foo<br/>bar", "foo\n\nbar"),
+                Arguments.of("         <p>foo</p>", "foo")
         );
     }
 }

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/DocumentationConverterTest.java
@@ -31,6 +31,10 @@ public class DocumentationConverterTest {
                         "a link (https://example.com)"
                 ),
                 Arguments.of(
+                        "<a>empty link</a>",
+                        "empty link"
+                ),
+                Arguments.of(
                         "<ul><li>Testing 1 2 3</li> <li>FooBar</li></ul>",
                         "    * Testing 1 2 3\n\n    * FooBar"
                 ),


### PR DESCRIPTION
This fixes two documentation formatting issues:

1. It fixes an issue where some HTML block were being interpreted as code blocks due to liberal use of indentation. It does this by disabling the indented code block parsing entirely, which seems like an acceptable trade since commonmark allows fenced code blocks that people tend to prefer in my experience.
2. It fixes an issue where anchors without references were being rendered.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
