### PR TITLE
Wrap request bodies in safe reader to prevent data race conditions.

### DIFF
--- a/transport/http/internal/io/safe.go
+++ b/transport/http/internal/io/safe.go
@@ -1,0 +1,75 @@
+package io
+
+import (
+	"io"
+	"sync"
+)
+
+// NewSafeReadCloser returns a new safeReadCloser that wraps readCloser.
+func NewSafeReadCloser(readCloser io.ReadCloser) io.ReadCloser {
+	sr := &safeReadCloser{
+		readCloser: readCloser,
+	}
+
+	if _, ok := readCloser.(io.WriterTo); ok {
+		return &safeWriteToReadCloser{safeReadCloser: sr}
+	}
+
+	return sr
+}
+
+// safeWriteToReadCloser wraps a safeReadCloser but exposes a WriteTo interface implementation. This will panic
+// if the underlying io.ReadClose does not support WriteTo. Use NewSafeReadCloser to ensure the proper handling of this
+// type.
+type safeWriteToReadCloser struct {
+	*safeReadCloser
+}
+
+// WriteTo implements the io.WriteTo interface.
+func (r *safeWriteToReadCloser) WriteTo(w io.Writer) (int64, error) {
+	r.safeReadCloser.mtx.Lock()
+	defer r.safeReadCloser.mtx.Unlock()
+
+	if r.safeReadCloser.closed {
+		return 0, io.EOF
+	}
+
+	return r.safeReadCloser.readCloser.(io.WriterTo).WriteTo(w)
+}
+
+// safeReadCloser wraps a io.ReadCloser and presents an io.ReadCloser interface. When Close is called on safeReadCloser
+// the underlying Close method will be executed, and then the reference to the reader will be dropped. This type
+// is meant to be used with the net/http library which will retain a reference to the request body for the lifetime
+// of a goroutine connection. Wrapping in this manner will ensure that no data race conditions are falsely reported.
+// This type is thread-safe.
+type safeReadCloser struct {
+	readCloser io.ReadCloser
+	closed     bool
+	mtx        sync.Mutex
+}
+
+// Read reads up to len(p) bytes into p from the underlying read. If the reader is closed io.EOF will be returned.
+func (r *safeReadCloser) Read(p []byte) (n int, err error) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if r.closed {
+		return 0, io.EOF
+	}
+
+	return r.readCloser.Read(p)
+}
+
+// Close calls the underlying io.ReadCloser's Close method, removes the reference to the reader, and returns any error
+// reported from Close. Subsequent calls to Close will always return a nil error.
+func (r *safeReadCloser) Close() error {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if r.closed {
+		return nil
+	}
+
+	r.closed = true
+	rc := r.readCloser
+	r.readCloser = nil
+	return rc.Close()
+}

--- a/transport/http/internal/io/safe_test.go
+++ b/transport/http/internal/io/safe_test.go
@@ -1,0 +1,170 @@
+package io
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+type mockReadCloser struct {
+	ReadFn  func([]byte) (int, error)
+	CloseFn func() error
+}
+
+func (m *mockReadCloser) Read(p []byte) (n int, err error) {
+	if m.ReadFn == nil {
+		return len(p), nil
+	}
+	return m.ReadFn(p)
+}
+
+func (m *mockReadCloser) Close() error {
+	if m.CloseFn == nil {
+		return nil
+	}
+	return m.CloseFn()
+}
+
+type mockWriteTo struct {
+	mockReadCloser
+	WriteToFn func(io.Writer) (int64, error)
+}
+
+func (m *mockWriteTo) WriteTo(w io.Writer) (int64, error) {
+	if m.WriteToFn == nil {
+		return 0, nil
+	}
+	return m.WriteToFn(w)
+}
+
+func TestNewSafeReadCloser(t *testing.T) {
+	cases := map[string]struct {
+		ReadCloser io.ReadCloser
+		ReadTest   func(*testing.T, *safeReadCloser)
+		CloseTest  func(*testing.T, *safeReadCloser)
+	}{
+		"success read and close": {
+			ReadCloser: &mockReadCloser{
+				ReadFn: func(bytes []byte) (int, error) {
+					bytes[0], bytes[1], bytes[2] = 'f', 'o', 'o'
+					return 3, nil
+				},
+			},
+			ReadTest: func(t *testing.T, closer *safeReadCloser) {
+				t.Helper()
+				bs := make([]byte, 3)
+				read, err := closer.Read(bs)
+				if err != nil {
+					t.Errorf("expect no error, got %v", err)
+				}
+				if e, a := "foo", string(bs[:read]); e != a {
+					t.Errorf("expect %v, got %v", e, a)
+				}
+			},
+			CloseTest: func(t *testing.T, closer *safeReadCloser) {
+				t.Helper()
+				if err := closer.Close(); err != nil {
+					t.Errorf("expect no error, got %v", err)
+				}
+			},
+		},
+		"error read": {
+			ReadCloser: &mockReadCloser{
+				ReadFn: func(bytes []byte) (int, error) {
+					return 0, io.ErrUnexpectedEOF
+				},
+			},
+			ReadTest: func(t *testing.T, closer *safeReadCloser) {
+				t.Helper()
+				_, err := closer.Read([]byte{})
+				if err == nil {
+					t.Errorf("expect error, got nil")
+				}
+				if !errors.Is(err, io.ErrUnexpectedEOF) {
+					t.Errorf("expect error to be type %T, got %T", io.ErrUnexpectedEOF, err)
+				}
+			},
+		},
+		"error close": {
+			ReadCloser: &mockReadCloser{
+				CloseFn: func() error {
+					return fmt.Errorf("foobar error")
+				},
+			},
+			CloseTest: func(t *testing.T, closer *safeReadCloser) {
+				t.Helper()
+				if err := closer.Close(); err == nil {
+					t.Error("expect close error, got nil")
+				} else if e, a := "foobar error", err.Error(); e != a {
+					t.Errorf("expect %v, got %v", e, a)
+				}
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			sr := NewSafeReadCloser(tt.ReadCloser).(*safeReadCloser)
+			if e, a := false, sr.closed; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+			if tt.ReadTest != nil {
+				tt.ReadTest(t, sr)
+			}
+			if tt.CloseTest != nil {
+				tt.CloseTest(t, sr)
+			} else {
+				sr.Close()
+			}
+			if e, a := true, sr.closed; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+			if sr.readCloser != nil {
+				t.Errorf("expect reader to be nil after Close")
+			}
+			if err := sr.Close(); err != nil {
+				t.Errorf("expect subsequent Close returns to be nil, got %v", err)
+			}
+		})
+	}
+}
+
+func TestNewSafeReadCloser_WriteTo(t *testing.T) {
+	{
+		rc := &mockWriteTo{}
+		writeToReadCloser := NewSafeReadCloser(rc).(*safeWriteToReadCloser)
+		_, err := writeToReadCloser.WriteTo(nil)
+		if err != nil {
+			t.Errorf("expect no error, got %v", err)
+		}
+
+		err = writeToReadCloser.Close()
+		if err != nil {
+			t.Errorf("expect no error, got %v", err)
+		}
+
+		_, err = writeToReadCloser.WriteTo(nil)
+		if err != io.EOF {
+			t.Errorf("expect %T, got %T", io.EOF, err)
+		}
+	}
+	{
+		rc := &mockWriteTo{
+			WriteToFn: func(writer io.Writer) (int64, error) {
+				write, err := writer.Write([]byte("foo"))
+				return int64(write), err
+			},
+		}
+		writeToReadCloser := NewSafeReadCloser(rc).(*safeWriteToReadCloser)
+		var buf bytes.Buffer
+		_, err := writeToReadCloser.WriteTo(&buf)
+		if err != nil {
+			t.Errorf("expect no error, got %v", err)
+		}
+		if e, a := "foo", buf.String(); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+	}
+}


### PR DESCRIPTION
Wraps the request body io.ReadCloser in a safe io.ReadCloser that will not retain references to the underlying reader after close has been called. Supports exposing `WriteTo` interface method if support by the `io.ReadCloser` type. This allows for `io.Copy(dst, src)` to take advantage of this if the optimization is available on the type.