### PR TITLE
Add HostnameImmutable context value for middleware

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -109,6 +109,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.2.1";
+        private static final String SMITHY_GO = "v0.2.2-0.20201026231331-345290040c23";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EndpointHostPrefixMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EndpointHostPrefixMiddleware.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ *
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.GoDelegator;
+import software.amazon.smithy.go.codegen.GoSettings;
+import software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.pattern.SmithyPattern;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.EndpointTrait;
+
+public class EndpointHostPrefixMiddleware implements GoIntegration {
+
+    private static final String MIDDLEWARE_ID = "EndpointHostPrefix";
+
+    List<RuntimeClientPlugin> runtimeClientPlugins = new ArrayList<>();
+    List<OperationShape> endpointPrefixOperations = new ArrayList<>();
+
+    @Override
+    public void processFinalizedModel(GoSettings settings, Model model) {
+        ServiceShape service = settings.getService(model);
+        endpointPrefixOperations = getOperationsWithEndpointPrefix(model, service);
+
+        endpointPrefixOperations.forEach((operation) -> {
+            String middlewareHelperName = getMiddlewareHelperName(operation);
+            runtimeClientPlugins.add(RuntimeClientPlugin.builder()
+                    .operationPredicate((m, s, o) -> o.equals(operation))
+                    .registerMiddleware(MiddlewareRegistrar.builder()
+                            .resolvedFunction(SymbolUtils.createValueSymbolBuilder(middlewareHelperName).build())
+                            .build())
+                    .build()
+            );
+        });
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return runtimeClientPlugins;
+    }
+
+    @Override
+    public void writeAdditionalFiles(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoDelegator delegator
+    ) {
+        endpointPrefixOperations.forEach((operation) -> {
+            delegator.useShapeWriter(operation, (writer) -> {
+                SmithyPattern pattern = operation.expectTrait(EndpointTrait.class).getHostPrefix();
+
+                writeMiddleware(writer, model, symbolProvider, operation, pattern);
+
+                String middlewareName = getMiddlewareName(operation);
+                String middlewareHelperName = getMiddlewareHelperName(operation);
+                writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
+                writer.openBlock("func $L(stack *middleware.Stack) error {", "}",
+                        middlewareHelperName,
+                        () -> {
+                            writer.write(
+                                    "return stack.Serialize.Insert(&$L{}, `OperationSerializer`, middleware.Before)",
+                                    middlewareName);
+                        });
+
+            });
+        });
+    }
+
+    private static void writeMiddleware(
+            GoWriter writer,
+            Model model,
+            SymbolProvider symbolProvider,
+            OperationShape operation,
+            SmithyPattern pattern
+    ) {
+        GoStackStepMiddlewareGenerator middlewareGenerator =
+                GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
+                        getMiddlewareName(operation),
+                        MIDDLEWARE_ID
+                );
+
+        middlewareGenerator.writeMiddleware(writer, (generator, w) -> {
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
+            writer.addUseImports(SmithyGoDependency.FMT);
+
+            w.openBlock("if smithyhttp.GetHostnameImmutable(ctx) {", "}", () -> {
+                w.write("return next.$L(ctx, in)", generator.getHandleMethodName());
+            }).write("");
+
+            w.write("req, ok := in.Request.(*smithyhttp.Request)");
+            w.openBlock("if !ok {", "}", () -> {
+                writer.write("return out, metadata, fmt.Errorf(\"unknown transport type %T\", in.Request)");
+            }).write("");
+
+            if (pattern.getLabels().isEmpty()) {
+                w.write("req.HostPrefix = $S", pattern.toString());
+
+            } else {
+                // If the pattern has labels, we need to build up the host prefix using a string builder.
+                writer.addUseImports(SmithyGoDependency.STRINGS);
+                writer.addUseImports(SmithyGoDependency.SMITHY);
+                StructureShape input = ProtocolUtils.expectInput(model, operation);
+                writer.write("input, ok := in.Parameters.($P)", symbolProvider.toSymbol(input));
+                w.openBlock("if !ok {", "}", () -> {
+                    writer.write("return out, metadata, fmt.Errorf(\"unknown input type %T\", in.Parameters)");
+                }).write("");
+
+                w.write("var prefix strings.Builder");
+                for (SmithyPattern.Segment segment : pattern.getSegments()) {
+                    if (!segment.isLabel()) {
+                        w.write("prefix.WriteString($S)", segment.toString());
+                    } else {
+                        MemberShape member = input.getMember(segment.getContent()).get();
+                        String memberName = symbolProvider.toMemberName(member);
+                        String memberReference = "input." + memberName;
+
+                        // Theoretically this should never be nil or empty by this point unless validation has
+                        // been disabled.
+                        w.write("if $L == nil {", memberReference).indent();
+                        w.write("return out, metadata, &smithy.SerializationError{Err: "
+                                        + "fmt.Errorf(\"$L forms part of the endpoint host and so may not be nil\")}",
+                                memberName);
+                        w.dedent().write("} else if !smithyhttp.ValidHostLabel(*$L) {", memberReference).indent();
+                        w.write("return out, metadata, &smithy.SerializationError{Err: "
+                                + "fmt.Errorf(\"$L forms part of the endpoint host and so must match "
+                                + "\\\"[a-zA-Z0-9-]{1,63}\\\""
+                                + ", but was \\\"%s\\\"\", *$L)}", memberName, memberReference);
+                        w.dedent().openBlock("} else {", "}", () -> {
+                            w.write("prefix.WriteString(*$L)", memberReference);
+                        });
+                    }
+                }
+
+                w.write("req.HostPrefix = prefix.String()");
+            }
+            w.write("");
+
+            w.write("return next.$L(ctx, in)", generator.getHandleMethodName());
+        });
+    }
+
+    /**
+     * Gets a list of the operations decorated with the EndpointTrait.
+     *
+     * @param model   Model used for generation.
+     * @param service Service for getting list of operations.
+     * @return list of operations decorated with the EndpointTrait.
+     */
+    public static List<OperationShape> getOperationsWithEndpointPrefix(Model model, ServiceShape service) {
+        List<OperationShape> operations = new ArrayList<>();
+        service.getAllOperations().stream().forEach((operationId) -> {
+            OperationShape operation = model.expectShape(operationId).asOperationShape().get();
+            if (!operation.hasTrait(EndpointTrait.ID)) {
+                return;
+            }
+
+            operations.add(operation);
+        });
+        return operations;
+    }
+
+    private static String getMiddlewareName(OperationShape operation) {
+        return String.format("endpointPrefix_op%sMiddleware", operation.getId().getName());
+    }
+
+    private static String getMiddlewareHelperName(OperationShape operation) {
+        return String.format("addEndpointPrefix_op%sMiddleware", operation.getId().getName());
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.isShapeWithResponseBindings;
-import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setHostPrefix;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.requiresDocumentSerdeFunction;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.writeSafeMemberAccessor;
 
@@ -213,8 +212,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
                         + " in.Parameters)}");
             });
-
-            setHostPrefix(context, operation);
 
             writer.write("");
             writer.write("opPath, opQuery := httpbinding.SplitURI($S)", httpTrait.getUri());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -15,8 +15,6 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
-import static software.amazon.smithy.go.codegen.integration.HttpProtocolGeneratorUtils.setHostPrefix;
-
 import java.util.Set;
 import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -118,8 +116,6 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                         + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
                         + " in.Parameters)}");
             }).write("");
-
-            setHostPrefix(context, operation);
 
             writer.write("request.Request.URL.Path = $S", getOperationPath(context, operation));
             writer.write("request.Request.Method = \"POST\"");

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -2,3 +2,4 @@ software.amazon.smithy.go.codegen.integration.ValidationGenerator
 software.amazon.smithy.go.codegen.integration.IdempotencyTokenMiddlewareGenerator
 software.amazon.smithy.go.codegen.integration.AddChecksumRequiredMiddleware
 software.amazon.smithy.go.codegen.integration.RequiresLengthTraitSupport
+software.amazon.smithy.go.codegen.integration.EndpointHostPrefixMiddleware

--- a/transport/http/middleware_metadata.go
+++ b/transport/http/middleware_metadata.go
@@ -1,0 +1,20 @@
+package http
+
+import "context"
+
+type (
+	hostnameImmutableKey struct{}
+)
+
+// GetHostnameImmutable retrieves if the endpoint hostname should be considered
+// immutable or not.
+func GetHostnameImmutable(ctx context.Context) (v bool) {
+	v, _ = ctx.Value(hostnameImmutableKey{}).(bool)
+	return v
+}
+
+// SetHostnameImmutable sets or modifies if the request's endpoint hostname
+// should be considered immutable or not.
+func SetHostnameImmutable(ctx context.Context, value bool) context.Context {
+	return context.WithValue(ctx, hostnameImmutableKey{}, value)
+}


### PR DESCRIPTION
Adds a new `HostnameImmutable` context value getter/setter helpers to `transport/http` package. 

Updates EndpointTrait's HostPrefix handling to use the HostnameImmutable to skip modifying the endpoint.

Also refactors EndpointTrait HostPrefix handling to be an integration instead of implemented directly in the operation serializer.