### PR TITLE
Call Close on SafeReadCloser after client.Do

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -73,6 +73,13 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 		}
 	}
 
+	// HTTP RoundTripper *should* close the request body. But this may not happen in a timely manner.
+	// So instead Smithy *Request Build wraps the body to be sent in a safe closer that will clear the
+	// stream reference so that it can be safely reused.
+	if builtRequest.Body != nil {
+		_ = builtRequest.Body.Close()
+	}
+
 	return &Response{Response: resp}, metadata, err
 }
 

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -131,15 +131,6 @@ func (r *Request) SetStream(reader io.Reader) (rc *Request, err error) {
 func (r *Request) Build(ctx context.Context) *http.Request {
 	req := r.Request.Clone(ctx)
 
-	// TODO special handling for unbounded streams like HTTP/2 for eventstream,
-	// or chunk transfer encoding.
-
-	// TODO handle case of unseekable stream, e.g. io.Reader, not io.ReadSeeker, or io.ReaderAt.
-
-	// TODO handle determination of when to close the underlying stream. Most
-	// likely want to defer this to the caller, and not allow the underlying
-	// http round tripper close the stream.
-
 	if r.stream != nil {
 		req.Body = iointernal.NewSafeReadCloser(ioutil.NopCloser(r.stream))
 	} else {


### PR DESCRIPTION
Closes the SafeReadCloser after each request attempt.