### PR TITLE
moves host prefix addition to a build step middleware

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -110,6 +110,6 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.14";
         private static final String GO_CMP = "v0.4.1";
-        private static final String SMITHY_GO = "v0.3.1-0.20201104233911-38864709e183";
+        private static final String SMITHY_GO = "v0.3.1-0.20201108010311-62c2a93810b4";
     }
 }

--- a/transport/http/middleware_metadata.go
+++ b/transport/http/middleware_metadata.go
@@ -4,6 +4,7 @@ import "context"
 
 type (
 	hostnameImmutableKey struct{}
+	hostPrefixDisableKey struct{}
 )
 
 // GetHostnameImmutable retrieves if the endpoint hostname should be considered
@@ -17,4 +18,18 @@ func GetHostnameImmutable(ctx context.Context) (v bool) {
 // should be considered immutable or not.
 func SetHostnameImmutable(ctx context.Context, value bool) context.Context {
 	return context.WithValue(ctx, hostnameImmutableKey{}, value)
+}
+
+// DisableEndpointHostPrefix sets or modifies if the request's endpoint host
+// prefixing to be disabled. If value is set to true, endpoint host prefixing
+// will be disabled.
+func DisableEndpointHostPrefix(ctx context.Context, value bool) context.Context {
+	return context.WithValue(ctx, hostPrefixDisableKey{}, value)
+}
+
+// IsEndpointHostPrefixDisabled retrieves if the hostname prefixing
+//  is disabled.
+func IsEndpointHostPrefixDisabled(ctx context.Context) (v bool) {
+	v, _ = ctx.Value(hostPrefixDisableKey{}).(bool)
+	return v
 }

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -18,7 +18,6 @@ type Request struct {
 	stream           io.Reader
 	isStreamSeekable bool
 	streamStartPos   int64
-	HostPrefix       string
 }
 
 // NewStackRequest returns an initialized request ready to populated with the
@@ -127,7 +126,7 @@ func (r *Request) SetStream(reader io.Reader) (rc *Request, err error) {
 
 // Build returns a build standard HTTP request value from the Smithy request.
 // The request's stream is wrapped in a safe container that allows it to be
-// reused for subsiquent attempts.
+// reused for subsequent attempts.
 func (r *Request) Build(ctx context.Context) *http.Request {
 	req := r.Request.Clone(ctx)
 
@@ -137,11 +136,6 @@ func (r *Request) Build(ctx context.Context) *http.Request {
 		// we update the content-length to 0,
 		// if request stream was not set.
 		req.ContentLength = 0
-	}
-
-	// Add the host prefix
-	if len(r.HostPrefix) != 0 {
-		req.URL.Host = r.HostPrefix + req.URL.Host
 	}
 
 	return req


### PR DESCRIPTION
*Issue #, if available:*

Endpoint host prefix addition was being performed after a request was signed. This led to a incorrectly signed request. 

*Description of changes:*

[x] This changes moves the endpoint mutation to a build step middleware, that will be performed before signing.  

[x] We also add a `DisableEndpointHostPrefix` and `IsEndpointHostPrefixDisabled` method on transport/http which provides an ability to turn host prefixing off. This would be useful when applying customizations or for testing purposes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Related to https://github.com/aws/aws-sdk-go-v2/pull/862 and https://github.com/aws/aws-sdk-go-v2/pull/863