### PR TITLE
update content length middleware to unset stream if stream is empty

### DIFF
--- a/transport/http/middleware_content_length.go
+++ b/transport/http/middleware_content_length.go
@@ -44,6 +44,12 @@ func (m *ComputeContentLength) HandleBuild(
 			"failed getting length of request stream, %w", err)
 	} else if ok {
 		req.ContentLength = n
+		if n == 0 {
+			// If the content length could be determined, and the body is empty
+			// the stream must be cleared to prevent unexpected chunk encoding.
+			req, _ = req.SetStream(nil)
+			in.Request = req
+		}
 	}
 
 	return next.HandleBuild(ctx, in)

--- a/transport/http/middleware_content_length_test.go
+++ b/transport/http/middleware_content_length_test.go
@@ -32,8 +32,11 @@ func TestContentLengthMiddleware(t *testing.T) {
 		},
 		"empty stream": {
 			Stream: strings.NewReader(""),
+			ExpectLen: 0,
 		},
-		"nil stream": {},
+		"nil stream": {
+			ExpectLen: 0,
+		},
 		"un-seekable and no length": {
 			Stream:    &basicReader{buf: make([]byte, 10)},
 			ExpectLen: -1,


### PR DESCRIPTION
*Issue #, if available:*

fixes https://github.com/aws/aws-sdk-go-v2/issues/915

*Description of changes:*

* unsets a request stream if the stream is empty.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
