### PR TITLE
Normalize map keys for shapes targeted by httpPrefixHeaders during deserialization 

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1086,7 +1086,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                         String value = generateHttpHeaderValue(context, writer, valueMemberShape,
                                 binding, operand);
-                        writer.write("v.$L[headerKey[lenPrefix:]] = $L", memberName,
+                        writer.write("v.$L[strings.ToLower(headerKey[lenPrefix:])] = $L", memberName,
                                 CodegenUtils.getAsPointerIfPointable(context.getModel(), writer,
                                         GoPointableIndex.of(context.getModel()), valueMemberShape, value));
                     });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.ShapeValueGenerator;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
@@ -135,6 +136,8 @@ public class HttpProtocolTestGenerator {
                             .service(service)
                             .operation(operation)
                             .testCases(trait.getTestCases())
+                            .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
+                                    .normalizeHttpPrefixHeaderKeys(true).build())
                             .build()
                             .generateTestFunction(writer);
                 });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
@@ -63,6 +63,7 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
     protected final String protocolName;
     protected final Set<ConfigValue> clientConfigValues = new TreeSet<>();
     protected final Set<SkipTest> skipTests = new TreeSet<>();
+    protected final ShapeValueGenerator.Config shapeValueGeneratorConfig;
 
     /**
      * Initializes the abstract protocol tests generator.
@@ -78,6 +79,7 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
         this.testCases = SmithyBuilder.requiredState("testCases", builder.testCases);
         this.clientConfigValues.addAll(builder.clientConfigValues);
         this.skipTests.addAll(builder.skipTests);
+        this.shapeValueGeneratorConfig = SmithyBuilder.requiredState("config", builder.shapeValueGeneratorConfig);
 
         opSymbol = symbolProvider.toSymbol(operation);
 
@@ -548,7 +550,7 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
      * @param params values to initialize shape type with.
      */
     protected void writeShapeValueInline(GoWriter writer, StructureShape shape, ObjectNode params) {
-        new ShapeValueGenerator(model, symbolProvider)
+        new ShapeValueGenerator(model, symbolProvider, shapeValueGeneratorConfig)
                 .writePointableStructureShapeValueInline(writer, shape, params);
     }
 
@@ -575,6 +577,7 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
         protected List<T> testCases = new ArrayList<>();
         protected Set<ConfigValue> clientConfigValues = new TreeSet<>();
         protected Set<SkipTest> skipTests = new TreeSet<>();
+        protected ShapeValueGenerator.Config shapeValueGeneratorConfig = ShapeValueGenerator.Config.builder().build();
 
         public Builder<T> model(Model model) {
             this.model = model;
@@ -638,6 +641,11 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
 
         public Builder<T> addSkipTests(Set<SkipTest> skipTests) {
             this.skipTests.addAll(skipTests);
+            return this;
+        }
+
+        public Builder<T> shapeValueGeneratorConfig(ShapeValueGenerator.Config config) {
+            this.shapeValueGeneratorConfig = config;
             return this;
         }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoUsageIndex.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoUsageIndex.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.knowledge;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.KnowledgeIndex;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.neighbor.RelationshipDirection;
+import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.ToShapeId;
+
+/**
+ * Provides {@link KnowledgeIndex} of how shapes are used in the model.
+ */
+public class GoUsageIndex implements KnowledgeIndex {
+    private final Model model;
+    private final Walker walker;
+
+    private final Set<ShapeId> inputShapes = new HashSet<>();
+    private final Set<ShapeId> outputShapes = new HashSet<>();
+
+    public GoUsageIndex(Model model) {
+        this.model = model;
+        this.walker = new Walker(model);
+
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        OperationIndex operationIndex = OperationIndex.of(model);
+
+        model.shapes(ServiceShape.class).forEach(serviceShape -> {
+            topDownIndex.getContainedOperations(serviceShape).forEach(operationShape -> {
+                StructureShape inputShape = operationIndex.getInput(operationShape).get();
+                StructureShape outputShape = operationIndex.getOutput(operationShape).get();
+
+                inputShapes.addAll(walker.walkShapes(inputShape, relationship ->
+                        relationship.getDirection() == RelationshipDirection.DIRECTED).stream()
+                        .map(Shape::toShapeId).collect(Collectors.toList()));
+
+                outputShapes.addAll(walker.walkShapes(outputShape, relationship ->
+                        relationship.getDirection() == RelationshipDirection.DIRECTED).stream()
+                        .map(Shape::toShapeId).collect(Collectors.toList()));
+
+            });
+        });
+    }
+
+    /**
+     * Returns whether shape is used as part of an input to an operation.
+     *
+     * @param shape the shape
+     * @return whether the shape is used as input.
+     */
+    public boolean isUsedForInput(ToShapeId shape) {
+        return inputShapes.contains(shape.toShapeId());
+    }
+
+    /**
+     * Returns whether shape is used as output of an operation.
+     *
+     * @param shape the shape
+     * @return whether the shape is used as input.
+     */
+    public boolean isUsedForOutput(ToShapeId shape) {
+        return outputShapes.contains(shape.toShapeId());
+    }
+
+    public static GoUsageIndex of(Model model) {
+        return model.getKnowledge(GoUsageIndex.class, GoUsageIndex::new);
+    }
+}


### PR DESCRIPTION
Normalizes map keys for shapes targeted by httpPrefixHeaders during deserialization. Also adds a comment when writing docs that are affected by this.